### PR TITLE
feat: add shared coordinate editor utilities

### DIFF
--- a/src/admin/hooks/useCoordinateHistory.ts
+++ b/src/admin/hooks/useCoordinateHistory.ts
@@ -1,0 +1,41 @@
+import { useCallback, useRef } from 'react'
+
+/** История координат для Ctrl+Z / Ctrl+Shift+Z (без привязки к полям ввода текста). */
+export function useCoordinateHistory<T>() {
+    const undoStack = useRef<string[]>([])
+    const redoStack = useRef<string[]>([])
+
+    const reset = useCallback(() => {
+        undoStack.current = []
+        redoStack.current = []
+    }, [])
+
+    /** Перед заменой координат сохранить предыдущее состояние и сбросить redo. */
+    const prepareCommit = useCallback((previous: T) => {
+        undoStack.current.push(JSON.stringify(previous))
+        redoStack.current = []
+    }, [])
+
+    const undo = useCallback((current: T): T | null => {
+        if (undoStack.current.length === 0) return null
+        const raw = undoStack.current.pop()
+        if (raw === undefined) return null
+        redoStack.current.push(JSON.stringify(current))
+        return JSON.parse(raw) as T
+    }, [])
+
+    const redo = useCallback((current: T): T | null => {
+        if (redoStack.current.length === 0) return null
+        const raw = redoStack.current.pop()
+        if (raw === undefined) return null
+        undoStack.current.push(JSON.stringify(current))
+        return JSON.parse(raw) as T
+    }, [])
+
+    return { reset, prepareCommit, undo, redo }
+}
+
+export function isUndoRedoBlockedTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false
+    return Boolean(target.closest('input, textarea, select, [contenteditable="true"]'))
+}

--- a/src/utils/fetchMissingRouteElevations.ts
+++ b/src/utils/fetchMissingRouteElevations.ts
@@ -1,0 +1,60 @@
+import type { RouteEditorCoordinates } from '@/admin/components/AdminRoutePolylineMap'
+
+const OPEN_METEO_ELEVATION_URL = 'https://api.open-meteo.com/v1/elevation'
+const BATCH_SIZE = 100
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+    const out: T[][] = []
+    for (let i = 0; i < items.length; i += size) {
+        out.push(items.slice(i, i + size))
+    }
+    return out
+}
+
+/**
+ * Заполняет высоту только у точек, где третья координата отсутствует.
+ * Использует Open-Meteo Elevation API, чтобы не требовать отдельный ключ.
+ */
+export async function fillMissingRouteElevations(
+    coordinates: RouteEditorCoordinates,
+): Promise<RouteEditorCoordinates> {
+    const missing = coordinates
+        .map((coord, index) => ({ coord, index }))
+        .filter(({ coord }) => coord.length < 3)
+
+    if (missing.length === 0) return [...coordinates]
+
+    const elevations: number[] = []
+    for (const group of chunk(missing, BATCH_SIZE)) {
+        const latitude = group.map(({ coord }) => String(coord[1])).join(',')
+        const longitude = group.map(({ coord }) => String(coord[0])).join(',')
+        const url = `${OPEN_METEO_ELEVATION_URL}?latitude=${encodeURIComponent(latitude)}&longitude=${encodeURIComponent(longitude)}`
+
+        const response = await fetch(url)
+        if (!response.ok) {
+            throw new Error(`Не удалось получить высоты (${String(response.status)}).`)
+        }
+
+        const payload = (await response.json()) as { elevation?: unknown }
+        if (!Array.isArray(payload.elevation) || payload.elevation.length !== group.length) {
+            throw new Error('API высот вернул неожиданный ответ.')
+        }
+
+        for (const value of payload.elevation) {
+            if (typeof value !== 'number' || !Number.isFinite(value)) {
+                throw new Error('API высот вернул некорректные значения.')
+            }
+            elevations.push(value)
+        }
+    }
+
+    const next: RouteEditorCoordinates = [...coordinates]
+    let eIdx = 0
+    for (const { index } of missing) {
+        const src = next[index]
+        const ele = elevations[eIdx]
+        next[index] = [src[0], src[1], ele]
+        eIdx += 1
+    }
+    return next
+}

--- a/src/utils/platformShortcuts.ts
+++ b/src/utils/platformShortcuts.ts
@@ -1,0 +1,22 @@
+export interface UndoRedoShortcuts {
+    undo: string
+    redo: string
+}
+
+function isApplePlatform(): boolean {
+    if (typeof navigator === 'undefined') return false
+
+    const navWithUaData = navigator as Navigator & { userAgentData?: { platform?: string } }
+    const uaPlatform = navWithUaData.userAgentData?.platform
+    if (typeof uaPlatform === 'string' && /(mac|iphone|ipad|ipod)/i.test(uaPlatform)) return true
+
+    return /(mac|iphone|ipad|ipod)/i.test(navigator.platform)
+}
+
+/** Подписи клавиш для текущей платформы пользователя. */
+export function getUndoRedoShortcuts(): UndoRedoShortcuts {
+    if (isApplePlatform()) {
+        return { undo: '⌘+Z', redo: '⌘+Shift+Z' }
+    }
+    return { undo: 'Ctrl+Z', redo: 'Ctrl+Shift+Z' }
+}

--- a/src/utils/routeVertexElevationStats.test.ts
+++ b/src/utils/routeVertexElevationStats.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { routeVertexElevationStats, type RouteVertexCoord } from '@/utils/routeVertexElevationStats'
+
+describe('routeVertexElevationStats', () => {
+    it('пустой массив', () => {
+        expect(routeVertexElevationStats([])).toEqual({
+            vertexCount: 0,
+            withElevationCount: 0,
+            withoutElevationCount: 0,
+        })
+    })
+
+    it('только без высоты', () => {
+        const coords: RouteVertexCoord[] = [
+            [0, 0],
+            [1, 1],
+        ]
+        expect(routeVertexElevationStats(coords)).toEqual({
+            vertexCount: 2,
+            withElevationCount: 0,
+            withoutElevationCount: 2,
+        })
+    })
+
+    it('смешанный набор', () => {
+        const coords: RouteVertexCoord[] = [
+            [0, 0, 100],
+            [1, 1],
+            [2, 2, 200],
+        ]
+        expect(routeVertexElevationStats(coords)).toEqual({
+            vertexCount: 3,
+            withElevationCount: 2,
+            withoutElevationCount: 1,
+        })
+    })
+})

--- a/src/utils/routeVertexElevationStats.ts
+++ b/src/utils/routeVertexElevationStats.ts
@@ -1,0 +1,22 @@
+/** Вершина линии маршрута: [lng, lat] или [lng, lat, ele]. */
+export type RouteVertexCoord = readonly [number, number] | readonly [number, number, number]
+
+export interface RouteVertexElevationStats {
+    vertexCount: number
+    withElevationCount: number
+    withoutElevationCount: number
+}
+
+/** Подсчёт вершин и наличия третьей координаты (высота). */
+export function routeVertexElevationStats(coords: readonly RouteVertexCoord[]): RouteVertexElevationStats {
+    const vertexCount = coords.length
+    let withElevationCount = 0
+    for (const p of coords) {
+        if (p.length === 3) withElevationCount += 1
+    }
+    return {
+        vertexCount,
+        withElevationCount,
+        withoutElevationCount: vertexCount - withElevationCount,
+    }
+}

--- a/src/utils/simplifyRouteCollinear.test.ts
+++ b/src/utils/simplifyRouteCollinear.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { simplifyRouteCollinear, type RouteEditorCoord } from '@/utils/simplifyRouteCollinear'
+
+describe('simplifyRouteCollinear', () => {
+    it('не меняет 0–2 точки', () => {
+        expect(simplifyRouteCollinear([])).toEqual([])
+        expect(simplifyRouteCollinear([[0, 0]])).toEqual([[0, 0]])
+        expect(
+            simplifyRouteCollinear([
+                [1, 1],
+                [2, 2],
+            ]),
+        ).toEqual([
+            [1, 1],
+            [2, 2],
+        ])
+    })
+
+    it('убирает одну среднюю коллинеарную точку на отрезке', () => {
+        const r = simplifyRouteCollinear([
+            [0, 0],
+            [1, 0],
+            [2, 0],
+        ])
+        expect(r).toEqual([
+            [0, 0],
+            [2, 0],
+        ])
+    })
+
+    it('убирает цепочку коллинеарных промежуточных', () => {
+        const r = simplifyRouteCollinear([
+            [0, 0],
+            [1, 0],
+            [2, 0],
+            [3, 0],
+        ])
+        expect(r).toEqual([
+            [0, 0],
+            [3, 0],
+        ])
+    })
+
+    it('сохраняет излом', () => {
+        const orig: RouteEditorCoord[] = [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [2, 1],
+        ]
+        expect(simplifyRouteCollinear(orig)).toEqual(orig)
+    })
+
+    it('сохраняет третью точку если средняя не на отрезке (продолжение)', () => {
+        const orig: RouteEditorCoord[] = [
+            [0, 0],
+            [2, 0],
+            [1, 0],
+        ]
+        expect(simplifyRouteCollinear(orig)).toEqual(orig)
+    })
+
+    it('копирует высоту у сохранённых вершин', () => {
+        const r = simplifyRouteCollinear([
+            [0, 0, 10],
+            [1, 0, 20],
+            [2, 0, 30],
+        ])
+        expect(r).toEqual([
+            [0, 0, 10],
+            [2, 0, 30],
+        ])
+    })
+})

--- a/src/utils/simplifyRouteCollinear.ts
+++ b/src/utils/simplifyRouteCollinear.ts
@@ -1,0 +1,63 @@
+/** Вершина маршрута в редакторе: [lng, lat] или [lng, lat, ele]. */
+export type RouteEditorCoord = [number, number] | [number, number, number]
+
+function copyPt(p: RouteEditorCoord): RouteEditorCoord {
+    return p.length === 3 ? [p[0], p[1], p[2]] : [p[0], p[1]]
+}
+
+function lngLat(p: RouteEditorCoord): [number, number] {
+    return [p[0], p[1]]
+}
+
+/**
+ * Промежуточная точка B лишняя, если лежит на отрезке AC (плоскость lng/lat, допуск для float).
+ */
+function isRedundantMiddle(a: [number, number], b: [number, number], c: [number, number]): boolean {
+    const [ax, ay] = a
+    const [bx, by] = b
+    const [cx, cy] = c
+    const acx = cx - ax
+    const acy = cy - ay
+    const acLen = Math.hypot(acx, acy)
+    if (acLen < 1e-15) {
+        return Math.hypot(bx - ax, by - ay) < 1e-12 && Math.hypot(cx - bx, cy - by) < 1e-12
+    }
+    const abx = bx - ax
+    const aby = by - ay
+    const cross = abx * acy - aby * acx
+    const distToLine = Math.abs(cross) / acLen
+    if (distToLine > 1e-10) return false
+    const dot = abx * acx + aby * acy
+    const t = dot / (acLen * acLen)
+    return t >= -1e-9 && t <= 1 + 1e-9
+}
+
+/**
+ * Удаляет промежуточные вершины, лежащие на одной прямой со своими соседями на отрезке (вид полилинии не меняется).
+ * Крайние точки сохраняются; высота у сохранённых вершин копируется как была.
+ */
+export function simplifyRouteCollinear(coords: readonly RouteEditorCoord[]): RouteEditorCoord[] {
+    if (coords.length <= 2) return coords.map(copyPt)
+
+    const out: RouteEditorCoord[] = [copyPt(coords[0])]
+
+    for (let i = 1; i < coords.length; i += 1) {
+        out.push(copyPt(coords[i]))
+        while (out.length >= 3) {
+            const n = out.length
+            const pA = out[n - 3]
+            const pB = out[n - 2]
+            const pC = out[n - 1]
+            const A = lngLat(pA)
+            const B = lngLat(pB)
+            const C = lngLat(pC)
+            if (isRedundantMiddle(A, B, C)) {
+                out.splice(out.length - 2, 1)
+            } else {
+                break
+            }
+        }
+    }
+
+    return out
+}


### PR DESCRIPTION
## Summary
- add shared utilities for coordinate history and platform-aware undo/redo shortcut labels
- add route simplification and elevation stats helpers with tests
- add helper to fill missing route elevations via external elevation API

## Test plan
- [x] npm run lint
- [x] npm run build

Made with [Cursor](https://cursor.com)