### PR TITLE
feat: redesign route editing workflow in admin

### DIFF
--- a/src/admin/components/AdminRoutePolylineMap.tsx
+++ b/src/admin/components/AdminRoutePolylineMap.tsx
@@ -1,0 +1,375 @@
+import { useCallback, useEffect, useRef } from 'react'
+import mapboxgl, { Marker, type MapMouseEvent } from 'mapbox-gl'
+import { useMapbox } from '@/hooks/useMapbox'
+import { COLORS } from '@/constants'
+
+export type RouteEditorCoordinates = Array<[number, number] | [number, number, number]>
+
+interface AdminRoutePolylineMapProps {
+    coordinates: RouteEditorCoordinates
+    onChange: (next: RouteEditorCoordinates) => void
+    /** Наведение на маркер вершины (для подсветки строки в списке). */
+    onVertexHover?: (vertexIndex: number | null) => void
+}
+
+const SOURCE_ID = 'admin-route-editor-src'
+const LINE_LAYER_ID = 'admin-route-editor-line'
+/** Широкая невидимая линия для попадания кликом по трассе */
+const HIT_LAYER_ID = 'admin-route-editor-line-hit'
+
+/** Маркер финиша в редакторе (старт остаётся {@link COLORS.route}). */
+const ROUTE_EDITOR_FINISH_MARKER_HEX = '#15803d'
+
+const INTERMEDIATE_VERTEX_SIZE_PX = 14
+
+function createIntermediateVertexElement(): HTMLDivElement {
+    const el = document.createElement('div')
+    el.style.width = `${String(INTERMEDIATE_VERTEX_SIZE_PX)}px`
+    el.style.height = `${String(INTERMEDIATE_VERTEX_SIZE_PX)}px`
+    el.style.borderRadius = '50%'
+    el.style.backgroundColor = COLORS.route
+    el.style.border = '2px solid #fff'
+    el.style.boxSizing = 'border-box'
+    el.style.boxShadow = '0 1px 4px rgba(0, 0, 0, 0.35)'
+    el.style.cursor = 'grab'
+    return el
+}
+
+function toLineStringCoords(coords: RouteEditorCoordinates): [number, number][] {
+    return coords.map((p) => [p[0], p[1]])
+}
+
+function featureCollectionFromCoords(coords: RouteEditorCoordinates): GeoJSON.FeatureCollection {
+    const line = toLineStringCoords(coords)
+    if (line.length >= 2) {
+        return {
+            type: 'FeatureCollection',
+            features: [
+                {
+                    type: 'Feature',
+                    properties: {},
+                    geometry: { type: 'LineString', coordinates: line },
+                },
+            ],
+        }
+    }
+    return { type: 'FeatureCollection', features: [] }
+}
+
+/** Ближайшая точка на отрезке AB к P (плоские координаты lng/lat). */
+function closestOnSegment2D(
+    a: [number, number],
+    b: [number, number],
+    p: [number, number],
+): { point: [number, number]; distSq: number } {
+    const [ax, ay] = a
+    const [bx, by] = b
+    const [px, py] = p
+    const abx = bx - ax
+    const aby = by - ay
+    const apx = px - ax
+    const apy = py - ay
+    const ab2 = abx * abx + aby * aby
+    if (ab2 < 1e-20) {
+        const dx = px - ax
+        const dy = py - ay
+        return { point: a, distSq: dx * dx + dy * dy }
+    }
+    let t = (apx * abx + apy * aby) / ab2
+    t = Math.max(0, Math.min(1, t))
+    const cx = ax + t * abx
+    const cy = ay + t * aby
+    const distSq = (px - cx) ** 2 + (py - cy) ** 2
+    return { point: [cx, cy], distSq }
+}
+
+/** Куда вставить новую вершину на линии ближе всего к клику (индекс — позиция новой точки в массиве). */
+function findInsertIndexAndPoint(
+    line: [number, number][],
+    click: [number, number],
+): { insertIndex: number; point: [number, number] } | null {
+    if (line.length < 2) return null
+    let bestI = 0
+    let bestDist = Infinity
+    let bestPoint: [number, number] = line[0]
+    for (let i = 0; i < line.length - 1; i += 1) {
+        const r = closestOnSegment2D(line[i], line[i + 1], click)
+        if (r.distSq < bestDist) {
+            bestDist = r.distSq
+            bestI = i
+            bestPoint = r.point
+        }
+    }
+    return { insertIndex: bestI + 1, point: bestPoint }
+}
+
+function insertVertexAtIndex(
+    coords: RouteEditorCoordinates,
+    insertIndex: number,
+    point2d: [number, number],
+): RouteEditorCoordinates {
+    const next = [...coords]
+    next.splice(insertIndex, 0, [point2d[0], point2d[1]])
+    return next
+}
+
+function removeVertexAtIndex(coords: RouteEditorCoordinates, index: number): RouteEditorCoordinates {
+    if (coords.length <= 2 || index < 0 || index >= coords.length) return coords
+    return [...coords.slice(0, index), ...coords.slice(index + 1)]
+}
+
+function updateVertexLngLat(
+    coords: RouteEditorCoordinates,
+    index: number,
+    lng: number,
+    lat: number,
+): RouteEditorCoordinates {
+    if (index < 0 || index >= coords.length) return coords
+    const next = [...coords]
+    const prev = next[index]
+    if (prev.length === 3) {
+        next[index] = [lng, lat, prev[2]]
+    } else {
+        next[index] = [lng, lat]
+    }
+    return next
+}
+
+export function AdminRoutePolylineMap({
+    coordinates,
+    onChange,
+    onVertexHover,
+}: AdminRoutePolylineMapProps) {
+    const containerRef = useRef<HTMLDivElement | null>(null)
+    const { map, isMapReady } = useMapbox(containerRef)
+    const markersRef = useRef<Marker[]>([])
+    const onChangeRef = useRef(onChange)
+    const coordinatesRef = useRef(coordinates)
+    const hasToken = Boolean(import.meta.env.VITE_MAPBOX_TOKEN)
+    const onVertexHoverRef = useRef(onVertexHover)
+
+    useEffect(() => {
+        onVertexHoverRef.current = onVertexHover
+    }, [onVertexHover])
+
+    useEffect(() => {
+        onChangeRef.current = onChange
+    }, [onChange])
+
+    useEffect(() => {
+        coordinatesRef.current = coordinates
+    }, [coordinates])
+
+    const rebuildMarkers = useCallback((mapInstance: mapboxgl.Map, coords: RouteEditorCoordinates) => {
+        for (const m of markersRef.current) {
+            m.remove()
+        }
+        markersRef.current = []
+        const lastIndex = coords.length - 1
+        coords.forEach((coord, index) => {
+            const isIntermediate = coords.length >= 2 && index > 0 && index < lastIndex
+            const marker = isIntermediate
+                ? new Marker({ element: createIntermediateVertexElement(), draggable: true, anchor: 'center' })
+                : new Marker({
+                      color:
+                          coords.length >= 2 && index === lastIndex
+                              ? ROUTE_EDITOR_FINISH_MARKER_HEX
+                              : COLORS.route,
+                      draggable: true,
+                  })
+            marker.setLngLat([coord[0], coord[1]]).addTo(mapInstance)
+
+            const el = marker.getElement()
+            const onEnter = () => {
+                onVertexHoverRef.current?.(index)
+            }
+            const onLeave = () => {
+                onVertexHoverRef.current?.(null)
+            }
+            el.addEventListener('mouseenter', onEnter)
+            el.addEventListener('mouseleave', onLeave)
+
+            el.addEventListener(
+                'dblclick',
+                (ev) => {
+                    ev.preventDefault()
+                    ev.stopPropagation()
+                    const base = coordinatesRef.current
+                    if (base.length <= 2) return
+                    onChangeRef.current(removeVertexAtIndex(base, index))
+                },
+                true,
+            )
+
+            el.addEventListener(
+                'contextmenu',
+                (ev) => {
+                    ev.preventDefault()
+                    ev.stopPropagation()
+                    const base = coordinatesRef.current
+                    if (base.length <= 2) return
+                    onChangeRef.current(removeVertexAtIndex(base, index))
+                },
+                true,
+            )
+
+            marker.on('dragstart', () => {
+                onVertexHoverRef.current?.(null)
+            })
+
+            marker.on('dragend', () => {
+                const ll = marker.getLngLat()
+                const base = coordinatesRef.current
+                onChangeRef.current(updateVertexLngLat(base, index, ll.lng, ll.lat))
+            })
+
+            markersRef.current.push(marker)
+        })
+    }, [])
+
+    const applySourceData = useCallback((mapInstance: mapboxgl.Map, coords: RouteEditorCoordinates) => {
+        const fc = featureCollectionFromCoords(coords)
+        const src = mapInstance.getSource(SOURCE_ID)
+        if (src?.type === 'geojson') {
+            src.setData(fc)
+        }
+    }, [])
+
+    useEffect(() => {
+        if (!map || !isMapReady) return
+        map.doubleClickZoom.disable()
+
+        const ensureLayers = () => {
+            if (!map.getSource(SOURCE_ID)) {
+                map.addSource(SOURCE_ID, {
+                    type: 'geojson',
+                    data: featureCollectionFromCoords(coordinatesRef.current),
+                })
+                map.addLayer({
+                    id: LINE_LAYER_ID,
+                    type: 'line',
+                    source: SOURCE_ID,
+                    layout: {
+                        'line-cap': 'round',
+                        'line-join': 'round',
+                    },
+                    paint: {
+                        'line-color': COLORS.route,
+                        'line-width': 4,
+                        'line-opacity': 0.9,
+                    },
+                })
+                map.addLayer({
+                    id: HIT_LAYER_ID,
+                    type: 'line',
+                    source: SOURCE_ID,
+                    layout: {
+                        'line-cap': 'round',
+                        'line-join': 'round',
+                    },
+                    paint: {
+                        'line-color': '#000',
+                        'line-width': 18,
+                        'line-opacity': 0,
+                    },
+                })
+            } else {
+                applySourceData(map, coordinatesRef.current)
+            }
+        }
+
+        ensureLayers()
+
+        const onStyleLoad = () => {
+            ensureLayers()
+            rebuildMarkers(map, coordinatesRef.current)
+        }
+
+        map.on('style.load', onStyleLoad)
+
+        rebuildMarkers(map, coordinatesRef.current)
+        applySourceData(map, coordinatesRef.current)
+
+        const onMapClick = (e: MapMouseEvent) => {
+            const { lng, lat } = e.lngLat
+            const cur = coordinatesRef.current
+
+            const hits = map.queryRenderedFeatures(e.point, { layers: [HIT_LAYER_ID] })
+            const line2d = toLineStringCoords(cur)
+            if (hits.length > 0 && line2d.length >= 2) {
+                const found = findInsertIndexAndPoint(line2d, [lng, lat])
+                if (found) {
+                    onChangeRef.current(insertVertexAtIndex(cur, found.insertIndex, found.point))
+                    return
+                }
+            }
+
+            onChangeRef.current([...cur, [lng, lat]])
+        }
+
+        map.on('click', onMapClick)
+
+        const nav = new mapboxgl.NavigationControl({ showCompass: false, visualizePitch: false })
+        map.addControl(nav, 'bottom-right')
+
+        return () => {
+            map.doubleClickZoom.enable()
+            map.off('style.load', onStyleLoad)
+            map.off('click', onMapClick)
+            map.removeControl(nav)
+            for (const m of markersRef.current) {
+                m.remove()
+            }
+            markersRef.current = []
+            try {
+                if (map.getLayer(HIT_LAYER_ID)) map.removeLayer(HIT_LAYER_ID)
+                if (map.getLayer(LINE_LAYER_ID)) map.removeLayer(LINE_LAYER_ID)
+                if (map.getSource(SOURCE_ID)) map.removeSource(SOURCE_ID)
+            } catch {
+                // стиль мог быть сброшен
+            }
+        }
+    }, [map, isMapReady, applySourceData, rebuildMarkers])
+
+    useEffect(() => {
+        if (!map || !isMapReady) return
+        applySourceData(map, coordinates)
+        rebuildMarkers(map, coordinates)
+    }, [map, isMapReady, coordinates, applySourceData, rebuildMarkers])
+
+    /** Вписать линию в вид при открытии редактора (один раз при готовности карты). */
+    useEffect(() => {
+        if (!map || !isMapReady) return
+        const line = toLineStringCoords(coordinatesRef.current)
+        if (line.length >= 2) {
+            const bounds = new mapboxgl.LngLatBounds(line[0], line[0])
+            for (const p of line) {
+                bounds.extend(p)
+            }
+            map.fitBounds(bounds, { padding: 56, maxZoom: 15, duration: 0 })
+            return
+        }
+        if (line.length === 1) {
+            map.jumpTo({ center: line[0], zoom: 14 })
+        }
+    }, [map, isMapReady])
+
+    if (!hasToken) {
+        return (
+            <div className="flex min-h-[280px] w-full flex-1 items-center justify-center rounded-xl border border-neutral-200 bg-neutral-100 text-sm text-neutral-600 lg:min-h-0">
+                Задайте VITE_MAPBOX_TOKEN для редактора на карте.
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex min-h-[280px] w-full min-w-0 flex-1 flex-col gap-2 lg:min-h-0">
+            <p className="shrink-0 text-xs text-neutral-500">
+                Перетаскивайте вершины: старт красный и финиш зелёный. Клик по линии вставляет вершину на
+                выбранный сегмент, клик по пустому месту добавляет точку в конец. Правый клик по маркеру
+                вершины удаляет её (не ниже двух вершин). Для сохранения нужно минимум две вершины.
+            </p>
+            <div ref={containerRef} className="admin-editor-map rounded-xl border border-neutral-200" />
+        </div>
+    )
+}

--- a/src/admin/components/RouteVertexEditorList.tsx
+++ b/src/admin/components/RouteVertexEditorList.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useRef, useState } from 'react'
+import type { RouteEditorCoordinates } from '@/admin/components/AdminRoutePolylineMap'
+
+interface RouteVertexEditorListProps {
+    coordinates: RouteEditorCoordinates
+    /** Запись в историю undo и обновление состояния — как `commitRouteCoordinates` со страницы. */
+    onCoordinatesChange: (next: RouteEditorCoordinates) => void
+    onSimplifyRoute: () => void
+    onFillMissingElevations: () => void
+    fillingElevations?: boolean
+    highlightedIndex: number | null
+    onValidationError: (message: string | null) => void
+}
+
+function removeVertexAtIndex(coords: RouteEditorCoordinates, index: number): RouteEditorCoordinates {
+    if (coords.length <= 2 || index < 0 || index >= coords.length) return coords
+    return [...coords.slice(0, index), ...coords.slice(index + 1)]
+}
+
+function coordSignature(coord: RouteEditorCoordinates[number]): string {
+    return coord.length === 3
+        ? `${String(coord[0])},${String(coord[1])},${String(coord[2])}`
+        : `${String(coord[0])},${String(coord[1])}`
+}
+
+interface VertexRowProps {
+    index: number
+    coord: RouteEditorCoordinates[number]
+    vertexCount: number
+    highlighted: boolean
+    assignRowRef: (index: number, node: HTMLDivElement | null) => void
+    onCommit: (index: number, lngStr: string, latStr: string, eleRaw: string) => void
+    onRemove: (index: number) => void
+}
+
+function VertexRow({
+    index,
+    coord,
+    vertexCount,
+    highlighted,
+    assignRowRef,
+    onCommit,
+    onRemove,
+}: VertexRowProps) {
+    const [lngStr, setLngStr] = useState(() => String(coord[0]))
+    const [latStr, setLatStr] = useState(() => String(coord[1]))
+    const [eleStr, setEleStr] = useState(() => (coord.length === 3 ? String(coord[2]) : ''))
+
+    const rowNum = index + 1
+    /** Ширины в ch: lng/lat — типичные градусы, h — высота; при необходимости горизонтальная прокрутка внутри поля. */
+    const cellBase =
+        'box-border shrink-0 overflow-x-auto rounded border border-neutral-300 bg-white px-1 py-0.5 text-right font-mono text-xs leading-tight tabular-nums'
+
+    return (
+        <div
+            ref={(node) => {
+                assignRowRef(index, node)
+            }}
+            className={`flex min-w-0 items-center gap-1 rounded border px-1 py-0.5 transition-colors ${
+                highlighted ? 'border-amber-300 bg-amber-50' : 'border-neutral-200 bg-white'
+            }`}
+        >
+            <span className="box-border w-[4ch] shrink-0 text-right font-mono text-xs tabular-nums leading-tight text-neutral-800">
+                {rowNum}
+            </span>
+            <input
+                value={lngStr}
+                onChange={(e) => {
+                    setLngStr(e.target.value)
+                }}
+                onBlur={() => {
+                    onCommit(index, lngStr, latStr, eleStr)
+                }}
+                inputMode="decimal"
+                autoComplete="off"
+                aria-label={`${String(rowNum)} lng`}
+                className={`${cellBase} w-[11ch]`}
+            />
+            <input
+                value={latStr}
+                onChange={(e) => {
+                    setLatStr(e.target.value)
+                }}
+                onBlur={() => {
+                    onCommit(index, lngStr, latStr, eleStr)
+                }}
+                inputMode="decimal"
+                autoComplete="off"
+                aria-label={`${String(rowNum)} lat`}
+                className={`${cellBase} w-[11ch]`}
+            />
+            <input
+                value={eleStr}
+                onChange={(e) => {
+                    setEleStr(e.target.value)
+                }}
+                onBlur={() => {
+                    onCommit(index, lngStr, latStr, eleStr)
+                }}
+                inputMode="decimal"
+                autoComplete="off"
+                aria-label={`${String(rowNum)} h`}
+                className={`${cellBase} w-[7ch]`}
+            />
+            <button
+                type="button"
+                disabled={vertexCount <= 2}
+                onClick={() => {
+                    onRemove(index)
+                }}
+                className="shrink-0 rounded px-0.5 py-0.5 font-mono text-sm leading-none text-red-600 hover:bg-red-50 hover:text-red-700 disabled:cursor-not-allowed disabled:text-neutral-400 disabled:hover:bg-transparent"
+                aria-label={`Удалить вершину ${String(rowNum)}`}
+            >
+                ×
+            </button>
+        </div>
+    )
+}
+
+export function RouteVertexEditorList({
+    coordinates,
+    onCoordinatesChange,
+    onSimplifyRoute,
+    onFillMissingElevations,
+    fillingElevations = false,
+    highlightedIndex,
+    onValidationError,
+}: RouteVertexEditorListProps) {
+    const rowRefs = useRef<Map<number, HTMLDivElement>>(new Map())
+
+    const assignRowRef = (index: number, node: HTMLDivElement | null) => {
+        if (node) rowRefs.current.set(index, node)
+        else rowRefs.current.delete(index)
+    }
+
+    useEffect(() => {
+        if (highlightedIndex === null) return
+        const el = rowRefs.current.get(highlightedIndex)
+        el?.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'smooth' })
+    }, [highlightedIndex])
+
+    const commitVertex = (index: number, lngInput: string, latInput: string, eleRaw: string) => {
+        const lng = Number(lngInput.trim())
+        const lat = Number(latInput.trim())
+        const lngOk = Number.isFinite(lng) && lng >= -180 && lng <= 180
+        const latOk = Number.isFinite(lat) && lat >= -90 && lat <= 90
+        if (!lngOk || !latOk) {
+            onValidationError('Долгота и широта должны быть числами в допустимых пределах.')
+            return
+        }
+
+        const eleTrimmed = eleRaw.trim()
+        let nextTuple: RouteEditorCoordinates[number]
+        if (eleTrimmed !== '') {
+            const ele = Number(eleTrimmed)
+            if (!Number.isFinite(ele)) {
+                onValidationError('Высота должна быть числом или пустым полем.')
+                return
+            }
+            nextTuple = [lng, lat, ele]
+        } else {
+            nextTuple = [lng, lat]
+        }
+
+        const prev = coordinates[index]
+
+        const unchanged =
+            prev.length === nextTuple.length &&
+            prev[0] === nextTuple[0] &&
+            prev[1] === nextTuple[1] &&
+            (prev.length === 2 || (nextTuple.length === 3 && prev[2] === nextTuple[2]))
+
+        if (unchanged) {
+            onValidationError(null)
+            return
+        }
+
+        const next = [...coordinates]
+        next[index] = nextTuple
+        onCoordinatesChange(next)
+        onValidationError(null)
+    }
+
+    const removeAt = (index: number) => {
+        onCoordinatesChange(removeVertexAtIndex(coordinates, index))
+        onValidationError(null)
+    }
+
+    return (
+        <div className="flex min-h-0 flex-col gap-2">
+            <div className="flex items-center justify-between gap-2">
+                <label className="block text-xs font-medium text-neutral-700">Точки маршрута</label>
+                <div className="flex items-center gap-1">
+                    <button
+                        type="button"
+                        disabled={coordinates.length <= 2 || fillingElevations}
+                        onClick={() => {
+                            onSimplifyRoute()
+                        }}
+                        className="rounded border border-neutral-300 px-2 py-0.5 text-xs font-medium text-neutral-800 hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        title="Удалить промежуточные вершины, лежащие на прямой между соседями"
+                    >
+                        Упростить маршрут
+                    </button>
+                    <button
+                        type="button"
+                        disabled={fillingElevations}
+                        onClick={() => {
+                            onFillMissingElevations()
+                        }}
+                        className="rounded border border-neutral-300 px-2 py-0.5 text-xs font-medium text-neutral-800 hover:bg-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
+                        title="Заполнить высоту у точек, где она отсутствует"
+                    >
+                        {fillingElevations ? 'Заполнение…' : 'Заполнить высоты'}
+                    </button>
+                </div>
+            </div>
+            <div className="max-h-96 min-h-[12rem] overflow-y-auto rounded-lg border border-neutral-200 bg-neutral-50 p-1.5">
+                <div className="flex flex-col gap-1">
+                    {coordinates.map((coord, index) => (
+                        <VertexRow
+                            key={`${String(index)}-${coordSignature(coord)}`}
+                            index={index}
+                            coord={coord}
+                            vertexCount={coordinates.length}
+                            highlighted={highlightedIndex === index}
+                            assignRowRef={assignRowRef}
+                            onCommit={(i, lngN, latN, eleS) => {
+                                commitVertex(i, lngN, latN, eleS)
+                            }}
+                            onRemove={removeAt}
+                        />
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/admin/pages/RouteEditPage.tsx
+++ b/src/admin/pages/RouteEditPage.tsx
@@ -1,29 +1,44 @@
-import { useEffect, useState, type SyntheticEvent } from 'react'
+import { useCallback, useEffect, useMemo, useState, type SyntheticEvent } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { useCoordinateHistory, isUndoRedoBlockedTarget } from '@/admin/hooks/useCoordinateHistory'
 import {
     createRoute,
+    deleteRoute,
     getRoute,
     updateRoute,
     type AdminMapRoute,
 } from '@/admin/lib/adminApi'
+import { ConfirmDialog } from '@/admin/components/ConfirmDialog'
+import {
+    AdminRoutePolylineMap,
+    type RouteEditorCoordinates,
+} from '@/admin/components/AdminRoutePolylineMap'
+import { RouteVertexEditorList } from '@/admin/components/RouteVertexEditorList'
+import { fillMissingRouteElevations } from '@/utils/fetchMissingRouteElevations'
+import { getUndoRedoShortcuts } from '@/utils/platformShortcuts'
+import { routeVertexElevationStats } from '@/utils/routeVertexElevationStats'
+import { simplifyRouteCollinear } from '@/utils/simplifyRouteCollinear'
 
 interface RouteEditPageProps {
     mode: 'create' | 'edit'
 }
 
-type RouteCoordinates = Array<[number, number] | [number, number, number]>
-
 interface FormValue {
     title: string
     description: string
-    coordinatesText: string
+    coordinates: RouteEditorCoordinates
     flagDisabled: boolean
 }
+
+const DEFAULT_COORDINATES: RouteEditorCoordinates = [
+    [76.945, 43.238],
+    [76.95, 43.24],
+]
 
 const DEFAULT_VALUE: FormValue = {
     title: '',
     description: '',
-    coordinatesText: '[\n  [76.945, 43.238],\n  [76.95, 43.24]\n]',
+    coordinates: DEFAULT_COORDINATES,
     flagDisabled: false,
 }
 
@@ -31,43 +46,9 @@ function routeToFormValue(route: AdminMapRoute): FormValue {
     return {
         title: route.title,
         description: route.description ?? '',
-        coordinatesText: JSON.stringify(route.coordinates, null, 2),
+        coordinates: route.coordinates,
         flagDisabled: route.flag_disabled,
     }
-}
-
-function parseCoordinates(text: string): RouteCoordinates {
-    let parsed: unknown
-    try {
-        parsed = JSON.parse(text)
-    } catch {
-        throw new Error('Координаты должны быть валидным JSON.')
-    }
-    if (!Array.isArray(parsed) || parsed.length < 2) {
-        throw new Error('Нужно минимум 2 точки.')
-    }
-    const result: RouteCoordinates = []
-    for (const item of parsed as unknown[]) {
-        if (!Array.isArray(item) || item.length < 2 || item.length > 3) {
-            throw new Error('Каждая точка должна быть массивом [lng, lat] или [lng, lat, ele].')
-        }
-        const lng = item[0] as unknown
-        const lat = item[1] as unknown
-        if (typeof lng !== 'number' || lng < -180 || lng > 180) {
-            throw new Error('lng должен быть числом от -180 до 180.')
-        }
-        if (typeof lat !== 'number' || lat < -90 || lat > 90) {
-            throw new Error('lat должен быть числом от -90 до 90.')
-        }
-        if (item.length === 3) {
-            const ele = item[2] as unknown
-            if (typeof ele !== 'number') throw new Error('Высота должна быть числом.')
-            result.push([lng, lat, ele])
-        } else {
-            result.push([lng, lat])
-        }
-    }
-    return result
 }
 
 export function RouteEditPage({ mode }: RouteEditPageProps) {
@@ -78,6 +59,12 @@ export function RouteEditPage({ mode }: RouteEditPageProps) {
     const [value, setValue] = useState<FormValue | null>(mode === 'create' ? DEFAULT_VALUE : null)
     const [error, setError] = useState<string | null>(null)
     const [submitting, setSubmitting] = useState(false)
+    const [deleting, setDeleting] = useState(false)
+    const [confirmDelete, setConfirmDelete] = useState(false)
+    const [fillingElevations, setFillingElevations] = useState(false)
+    const [hoveredVertexIndex, setHoveredVertexIndex] = useState<number | null>(null)
+    const { reset: resetCoordHistory, prepareCommit, undo: undoCoordStep, redo: redoCoordStep } =
+        useCoordinateHistory<RouteEditorCoordinates>()
 
     useEffect(() => {
         if (mode !== 'edit' || routeId === null) return
@@ -85,7 +72,11 @@ export function RouteEditPage({ mode }: RouteEditPageProps) {
         void (async () => {
             try {
                 const route = await getRoute(routeId)
-                if (!state.cancelled) setValue(routeToFormValue(route))
+                if (!state.cancelled) {
+                    const fv = routeToFormValue(route)
+                    resetCoordHistory()
+                    setValue(fv)
+                }
             } catch (err) {
                 if (!state.cancelled) setError(err instanceof Error ? err.message : String(err))
             }
@@ -93,7 +84,55 @@ export function RouteEditPage({ mode }: RouteEditPageProps) {
         return () => {
             state.cancelled = true
         }
-    }, [mode, routeId])
+    }, [mode, routeId, resetCoordHistory])
+
+    const commitRouteCoordinates = useCallback(
+        (next: RouteEditorCoordinates) => {
+            setValue((prev) => {
+                if (!prev) return prev
+                if (JSON.stringify(prev.coordinates) === JSON.stringify(next)) return prev
+                prepareCommit(prev.coordinates)
+                return { ...prev, coordinates: next }
+            })
+        },
+        [prepareCommit],
+    )
+
+    const undoRouteCoordinates = useCallback(() => {
+        setValue((prev) => {
+            if (!prev) return prev
+            const restored = undoCoordStep(prev.coordinates)
+            if (restored === null) return prev
+            return { ...prev, coordinates: restored }
+        })
+    }, [undoCoordStep])
+
+    const redoRouteCoordinates = useCallback(() => {
+        setValue((prev) => {
+            if (!prev) return prev
+            const restored = redoCoordStep(prev.coordinates)
+            if (restored === null) return prev
+            return { ...prev, coordinates: restored }
+        })
+    }, [redoCoordStep])
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (!(event.ctrlKey || event.metaKey)) return
+            if (event.key.toLowerCase() !== 'z') return
+            if (isUndoRedoBlockedTarget(event.target)) return
+            event.preventDefault()
+            if (event.shiftKey) {
+                redoRouteCoordinates()
+            } else {
+                undoRouteCoordinates()
+            }
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => {
+            window.removeEventListener('keydown', onKeyDown)
+        }
+    }, [undoRouteCoordinates, redoRouteCoordinates])
 
     const handleSubmit = async (event: SyntheticEvent<HTMLFormElement>) => {
         event.preventDefault()
@@ -105,11 +144,8 @@ export function RouteEditPage({ mode }: RouteEditPageProps) {
             return
         }
 
-        let coordinates: RouteCoordinates
-        try {
-            coordinates = parseCoordinates(value.coordinatesText)
-        } catch (err) {
-            setError(err instanceof Error ? err.message : String(err))
+        if (value.coordinates.length < 2) {
+            setError('Нужно минимум две вершины маршрута.')
             return
         }
 
@@ -119,7 +155,7 @@ export function RouteEditPage({ mode }: RouteEditPageProps) {
             const payload = {
                 title: titleTrimmed,
                 description: value.description.trim() || null,
-                coordinates,
+                coordinates: value.coordinates,
                 flag_disabled: value.flagDisabled,
             }
             if (mode === 'create') {
@@ -136,101 +172,203 @@ export function RouteEditPage({ mode }: RouteEditPageProps) {
         }
     }
 
+    const handleDelete = async () => {
+        if (routeId === null) return
+        setDeleting(true)
+        try {
+            await deleteRoute(routeId)
+            await navigate('/admin/routes')
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setDeleting(false)
+            setConfirmDelete(false)
+        }
+    }
+
+    const simplifyRoute = () => {
+        if (!value || value.coordinates.length <= 2) return
+        commitRouteCoordinates(simplifyRouteCollinear(value.coordinates))
+    }
+
+    const fillRouteElevations = async () => {
+        if (!value) return
+        const hasMissing = value.coordinates.some((coord) => coord.length < 3)
+        if (!hasMissing) {
+            setError('Все точки уже содержат высоту.')
+            return
+        }
+
+        setError(null)
+        setFillingElevations(true)
+        try {
+            const next = await fillMissingRouteElevations(value.coordinates)
+            commitRouteCoordinates(next)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setFillingElevations(false)
+        }
+    }
+
+    const vertexStats = useMemo(
+        () => (value ? routeVertexElevationStats(value.coordinates) : null),
+        [value],
+    )
+
+    const effectiveHoveredVertexIndex = useMemo(() => {
+        if (!value || hoveredVertexIndex === null) return null
+        if (hoveredVertexIndex < 0 || hoveredVertexIndex >= value.coordinates.length) return null
+        return hoveredVertexIndex
+    }, [value, hoveredVertexIndex])
+    const shortcuts = useMemo(() => getUndoRedoShortcuts(), [])
+
     return (
-        <section className="max-w-3xl">
+        <section className="w-full max-w-none">
             <header className="mb-4">
                 <h1 className="text-xl font-semibold">
                     {mode === 'create' ? 'Новый маршрут' : `Маршрут #${params.id ?? ''}`}
                 </h1>
                 <p className="mt-1 text-sm text-neutral-600">
-                    Координаты — JSON-массив пар <code>[lng, lat]</code> (или <code>[lng, lat, ele]</code>),
-                    минимум две точки.
+                    Двойной клик по маркеру на карте удаляет вершину. Отмена шага: {shortcuts.undo}; повтор:{' '}
+                    {shortcuts.redo}
                 </p>
+                {mode === 'edit' && routeId !== null && (
+                    <div className="mt-3">
+                        <button
+                            type="button"
+                            disabled={deleting}
+                            onClick={() => {
+                                setConfirmDelete(true)
+                            }}
+                            className="rounded-lg border border-red-200 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
+                        >
+                            Удалить маршрут
+                        </button>
+                    </div>
+                )}
             </header>
 
             {error && <div className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
 
             {value ? (
-                <form
-                    className="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-white p-4"
-                    onSubmit={(event) => {
-                        void handleSubmit(event)
-                    }}
-                >
-                    <div>
-                        <label className="mb-1 block text-xs font-medium text-neutral-700">Название</label>
-                        <input
-                            value={value.title}
-                            onChange={(event) => {
-                                setValue({ ...value, title: event.target.value })
-                            }}
-                            maxLength={99}
-                            className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm"
-                        />
-                    </div>
+                <div className="grid w-full gap-6 lg:grid-cols-2 lg:items-stretch lg:gap-8 lg:min-h-[calc(100dvh-10rem)]">
+                    <form
+                        className="flex min-h-0 min-w-0 flex-col gap-4 rounded-xl border border-neutral-200 bg-white p-4"
+                        onSubmit={(event) => {
+                            void handleSubmit(event)
+                        }}
+                    >
+                        <div>
+                            <label className="mb-1 block text-xs font-medium text-neutral-700">Название</label>
+                            <input
+                                value={value.title}
+                                onChange={(event) => {
+                                    setValue({ ...value, title: event.target.value })
+                                }}
+                                maxLength={99}
+                                className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm"
+                            />
+                        </div>
 
-                    <div>
-                        <label className="mb-1 block text-xs font-medium text-neutral-700">Описание</label>
-                        <textarea
-                            value={value.description}
-                            onChange={(event) => {
-                                setValue({ ...value, description: event.target.value })
-                            }}
-                            rows={3}
-                            className="w-full resize-y rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm"
-                        />
-                    </div>
+                        <div>
+                            <label className="mb-1 block text-xs font-medium text-neutral-700">Описание</label>
+                            <textarea
+                                value={value.description}
+                                onChange={(event) => {
+                                    setValue({ ...value, description: event.target.value })
+                                }}
+                                rows={3}
+                                className="w-full resize-y rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm"
+                            />
+                        </div>
 
-                    <div>
-                        <label className="mb-1 block text-xs font-medium text-neutral-700">
-                            Координаты (JSON)
+                        <label className="flex items-center gap-2 text-sm text-neutral-700">
+                            <input
+                                type="checkbox"
+                                checked={value.flagDisabled}
+                                onChange={(event) => {
+                                    setValue({ ...value, flagDisabled: event.target.checked })
+                                }}
+                                className="h-4 w-4 rounded border-neutral-300 text-blue-600"
+                            />
+                            Скрыть с карты
                         </label>
-                        <textarea
-                            value={value.coordinatesText}
-                            onChange={(event) => {
-                                setValue({ ...value, coordinatesText: event.target.value })
-                            }}
-                            rows={12}
-                            spellCheck={false}
-                            className="w-full resize-y rounded-lg border border-neutral-300 bg-white px-3 py-2 font-mono text-xs"
-                        />
-                    </div>
 
-                    <label className="flex items-center gap-2 text-sm text-neutral-700">
-                        <input
-                            type="checkbox"
-                            checked={value.flagDisabled}
-                            onChange={(event) => {
-                                setValue({ ...value, flagDisabled: event.target.checked })
-                            }}
-                            className="h-4 w-4 rounded border-neutral-300 text-blue-600"
-                        />
-                        Скрыть с карты
-                    </label>
+                        {vertexStats && (
+                            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 rounded-lg border border-neutral-200 bg-neutral-50 px-3 py-1.5 text-xs text-neutral-800">
+                                <span className="font-medium text-neutral-600">Статистика</span>
+                                <span>Всего точек: {vertexStats.vertexCount}</span>
+                                <span>С высотой: {vertexStats.withElevationCount}</span>
+                                <span>Без высоты: {vertexStats.withoutElevationCount}</span>
+                            </div>
+                        )}
 
-                    <div className="flex gap-2">
-                        <button
-                            type="submit"
-                            disabled={submitting}
-                            className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:bg-blue-300"
-                        >
-                            {submitting ? 'Сохранение…' : mode === 'create' ? 'Создать' : 'Сохранить'}
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => {
-                                void navigate('/admin/routes')
+                        <RouteVertexEditorList
+                            coordinates={value.coordinates}
+                            onSimplifyRoute={simplifyRoute}
+                            onFillMissingElevations={() => {
+                                void fillRouteElevations()
                             }}
-                            disabled={submitting}
-                            className="rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium hover:bg-neutral-100 disabled:opacity-60"
-                        >
-                            Отмена
-                        </button>
+                            fillingElevations={fillingElevations}
+                            highlightedIndex={effectiveHoveredVertexIndex}
+                            onCoordinatesChange={commitRouteCoordinates}
+                            onValidationError={(message) => {
+                                setError(message)
+                            }}
+                        />
+
+                        <div className="flex gap-2">
+                            <button
+                                type="submit"
+                                disabled={submitting}
+                                className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:bg-blue-300"
+                            >
+                                {submitting ? 'Сохранение…' : mode === 'create' ? 'Создать' : 'Сохранить'}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    void navigate('/admin/routes')
+                                }}
+                                disabled={submitting}
+                                className="rounded-lg border border-neutral-300 px-4 py-2 text-sm font-medium hover:bg-neutral-100 disabled:opacity-60"
+                            >
+                                Отмена
+                            </button>
+                        </div>
+                    </form>
+
+                    <div className="flex min-h-[280px] min-w-0 flex-col gap-2 lg:min-h-0">
+                        <h2 className="shrink-0 text-sm font-medium text-neutral-800">Карта</h2>
+                        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+                            <AdminRoutePolylineMap
+                                coordinates={value.coordinates}
+                                onChange={(next) => {
+                                    commitRouteCoordinates(next)
+                                }}
+                                onVertexHover={setHoveredVertexIndex}
+                            />
+                        </div>
                     </div>
-                </form>
+                </div>
             ) : (
                 <p className="text-sm text-neutral-500">Загрузка…</p>
             )}
+
+            <ConfirmDialog
+                open={confirmDelete}
+                title="Удалить маршрут?"
+                description="Будет удалён маршрут. Действие необратимо."
+                confirmLabel="Удалить"
+                danger
+                onCancel={() => {
+                    if (!deleting) setConfirmDelete(false)
+                }}
+                onConfirm={() => {
+                    void handleDelete()
+                }}
+            />
         </section>
     )
 }


### PR DESCRIPTION
## Summary
- add dedicated admin route map component with draggable markers and click-to-insert vertex behavior
- replace JSON textarea with compact vertex list editor and hover sync from map to list
- add route-level actions for simplification, filling missing elevations, and coordinate stats display

## Test plan
- [x] npm run lint
- [x] npm run build

Made with [Cursor](https://cursor.com)