### PR TITLE
feat: add map-first point editing experience in admin

### DIFF
--- a/src/admin/components/AdminPointLocationMap.tsx
+++ b/src/admin/components/AdminPointLocationMap.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useRef } from 'react'
+import mapboxgl, { type MapMouseEvent, Marker } from 'mapbox-gl'
+import { useMapbox } from '@/hooks/useMapbox'
+import { COLORS } from '@/constants'
+
+interface AdminPointLocationMapProps {
+    coordinates: [number, number]
+    onChange: (next: [number, number]) => void
+}
+
+const EPS = 1e-7
+
+function coordsEqual(a: [number, number], b: [number, number]): boolean {
+    return Math.abs(a[0] - b[0]) < EPS && Math.abs(a[1] - b[1]) < EPS
+}
+
+export function AdminPointLocationMap({ coordinates, onChange }: AdminPointLocationMapProps) {
+    const containerRef = useRef<HTMLDivElement | null>(null)
+    const { map, isMapReady } = useMapbox(containerRef)
+    const markerRef = useRef<Marker | null>(null)
+    const onChangeRef = useRef(onChange)
+    const coordinatesRef = useRef(coordinates)
+    const hasToken = Boolean(import.meta.env.VITE_MAPBOX_TOKEN)
+
+    useEffect(() => {
+        onChangeRef.current = onChange
+    }, [onChange])
+
+    useEffect(() => {
+        coordinatesRef.current = coordinates
+    }, [coordinates])
+
+    /** Центрирование при первой загрузке карты (не при каждом вводе в полях). */
+    useEffect(() => {
+        if (!map || !isMapReady) return
+        const [lng, lat] = coordinatesRef.current
+        map.jumpTo({ center: [lng, lat], zoom: 14 })
+    }, [map, isMapReady])
+
+    useEffect(() => {
+        if (!map || !isMapReady) return
+
+        const marker = new Marker({ color: COLORS.point, draggable: true })
+            .setLngLat(coordinatesRef.current)
+            .addTo(map)
+
+        marker.on('dragend', () => {
+            const ll = marker.getLngLat()
+            onChangeRef.current([ll.lng, ll.lat])
+        })
+
+        markerRef.current = marker
+
+        const onMapClick = (e: MapMouseEvent) => {
+            const { lng, lat } = e.lngLat
+            onChangeRef.current([lng, lat])
+            marker.setLngLat([lng, lat])
+        }
+
+        map.on('click', onMapClick)
+
+        const nav = new mapboxgl.NavigationControl({ showCompass: false, visualizePitch: false })
+        map.addControl(nav, 'bottom-right')
+
+        return () => {
+            map.off('click', onMapClick)
+            map.removeControl(nav)
+            marker.remove()
+            markerRef.current = null
+        }
+    }, [map, isMapReady])
+
+    useEffect(() => {
+        if (!map || !isMapReady || !markerRef.current) return
+        const m = markerRef.current
+        const cur = m.getLngLat()
+        const curPair: [number, number] = [cur.lng, cur.lat]
+        if (coordsEqual(curPair, coordinates)) return
+        m.setLngLat(coordinates)
+    }, [map, isMapReady, coordinates])
+
+    if (!hasToken) {
+        return (
+            <div className="flex min-h-[280px] w-full flex-1 items-center justify-center rounded-xl border border-neutral-200 bg-neutral-100 text-sm text-neutral-600 lg:min-h-0">
+                Задайте VITE_MAPBOX_TOKEN для редактора на карте.
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex min-h-[280px] w-full min-w-0 flex-1 flex-col gap-2 lg:min-h-0">
+            <p className="shrink-0 text-xs text-neutral-500">
+                Перетащите маркер или кликните по карте, чтобы задать координаты.
+            </p>
+            <div ref={containerRef} className="admin-editor-map rounded-xl border border-neutral-200" />
+        </div>
+    )
+}

--- a/src/admin/components/PointForm.tsx
+++ b/src/admin/components/PointForm.tsx
@@ -1,6 +1,9 @@
-import { useState, type SyntheticEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type SyntheticEvent } from 'react'
 import type { MapPointType } from '@/types'
 import type { MapPointInput } from '@/admin/lib/adminApi'
+import { AdminPointLocationMap } from '@/admin/components/AdminPointLocationMap'
+import { useCoordinateHistory, isUndoRedoBlockedTarget } from '@/admin/hooks/useCoordinateHistory'
+import { getUndoRedoShortcuts } from '@/utils/platformShortcuts'
 
 export type PointFormValue = MapPointInput
 
@@ -16,6 +19,13 @@ const TYPE_OPTIONS: Array<{ value: MapPointType; label: string }> = [
     { value: 'socket', label: 'Розетка' },
 ]
 
+function parseCoordInput(raw: string, fallback: number): number {
+    const n = Number(raw)
+    return Number.isFinite(n) ? n : fallback
+}
+
+type CoordTuple = [number, number]
+
 export function PointForm({ initial, submitLabel, onSubmit, onCancel }: PointFormProps) {
     const [type, setType] = useState<MapPointType>(initial.type)
     const [title, setTitle] = useState(initial.title)
@@ -27,6 +37,69 @@ export function PointForm({ initial, submitLabel, onSubmit, onCancel }: PointFor
     const [flagDisabled, setFlagDisabled] = useState(initial.flag_disabled)
     const [submitting, setSubmitting] = useState(false)
     const [error, setError] = useState<string | null>(null)
+
+    const { reset: resetCoordHistory, prepareCommit, undo: undoCoordStep, redo: redoCoordStep } =
+        useCoordinateHistory<CoordTuple>()
+    const shortcuts = useMemo(() => getUndoRedoShortcuts(), [])
+    const lastCommittedCoords = useRef<CoordTuple>([initial.coordinates[0], initial.coordinates[1]])
+
+    useEffect(() => {
+        resetCoordHistory()
+    }, [resetCoordHistory])
+
+    const commitCoords = useCallback(
+        (next: CoordTuple) => {
+            const prev = lastCommittedCoords.current
+            if (prev[0] === next[0] && prev[1] === next[1]) return
+            prepareCommit(prev)
+            lastCommittedCoords.current = next
+            setLng(String(next[0]))
+            setLat(String(next[1]))
+        },
+        [prepareCommit],
+    )
+
+    const tryCommitCoordsFromInputs = useCallback(() => {
+        const lngNum = Number(lng)
+        const latNum = Number(lat)
+        if (!Number.isFinite(lngNum) || lngNum < -180 || lngNum > 180) return
+        if (!Number.isFinite(latNum) || latNum < -90 || latNum > 90) return
+        commitCoords([lngNum, latNum])
+    }, [lng, lat, commitCoords])
+
+    const undoCoords = useCallback(() => {
+        const restored = undoCoordStep(lastCommittedCoords.current)
+        if (!restored) return
+        lastCommittedCoords.current = restored
+        setLng(String(restored[0]))
+        setLat(String(restored[1]))
+    }, [undoCoordStep])
+
+    const redoCoords = useCallback(() => {
+        const restored = redoCoordStep(lastCommittedCoords.current)
+        if (!restored) return
+        lastCommittedCoords.current = restored
+        setLng(String(restored[0]))
+        setLat(String(restored[1]))
+    }, [redoCoordStep])
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (!(event.ctrlKey || event.metaKey)) return
+            if (event.key.toLowerCase() !== 'z') return
+            if (isUndoRedoBlockedTarget(event.target)) return
+            event.preventDefault()
+            if (event.shiftKey) {
+                redoCoords()
+            } else {
+                undoCoords()
+            }
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => {
+            window.removeEventListener('keydown', onKeyDown)
+        }
+    }, [undoCoords, redoCoords])
 
     const handleSubmit = async (event: SyntheticEvent<HTMLFormElement>) => {
         event.preventDefault()
@@ -67,13 +140,14 @@ export function PointForm({ initial, submitLabel, onSubmit, onCancel }: PointFor
     }
 
     return (
-        <form
-            className="flex flex-col gap-4 rounded-xl border border-neutral-200 bg-white p-4"
-            onSubmit={(event) => {
-                void handleSubmit(event)
-            }}
-        >
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="grid w-full gap-6 lg:grid-cols-2 lg:items-stretch lg:gap-8 lg:min-h-[calc(100dvh-10rem)]">
+            <form
+                className="flex min-h-0 flex-col gap-4 rounded-xl border border-neutral-200 bg-white p-4"
+                onSubmit={(event) => {
+                    void handleSubmit(event)
+                }}
+            >
+                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
                 <div>
                     <label className="mb-1 block text-xs font-medium text-neutral-700">Тип</label>
                     <select
@@ -129,6 +203,9 @@ export function PointForm({ initial, submitLabel, onSubmit, onCancel }: PointFor
                         onChange={(event) => {
                             setLng(event.target.value)
                         }}
+                        onBlur={() => {
+                            tryCommitCoordsFromInputs()
+                        }}
                         inputMode="decimal"
                         className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 font-mono text-sm"
                     />
@@ -139,6 +216,9 @@ export function PointForm({ initial, submitLabel, onSubmit, onCancel }: PointFor
                         value={lat}
                         onChange={(event) => {
                             setLat(event.target.value)
+                        }}
+                        onBlur={() => {
+                            tryCommitCoordsFromInputs()
                         }}
                         inputMode="decimal"
                         className="w-full rounded-lg border border-neutral-300 bg-white px-3 py-2 font-mono text-sm"
@@ -208,5 +288,26 @@ export function PointForm({ initial, submitLabel, onSubmit, onCancel }: PointFor
                 )}
             </div>
         </form>
+
+            <div className="flex min-h-[280px] min-w-0 flex-col gap-2 lg:min-h-0">
+                <div className="shrink-0">
+                    <h2 className="text-sm font-medium text-neutral-800">Карта</h2>
+                    <p className="mt-0.5 text-xs text-neutral-500">
+                        Отмена шага по координатам: {shortcuts.undo}; повтор: {shortcuts.redo} (не в полях ввода).
+                    </p>
+                </div>
+                <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+                    <AdminPointLocationMap
+                        coordinates={[
+                            parseCoordInput(lng, initial.coordinates[0]),
+                            parseCoordInput(lat, initial.coordinates[1]),
+                        ]}
+                        onChange={(next) => {
+                            commitCoords(next)
+                        }}
+                    />
+                </div>
+            </div>
+        </div>
     )
 }

--- a/src/admin/pages/PointEditPage.tsx
+++ b/src/admin/pages/PointEditPage.tsx
@@ -2,12 +2,15 @@ import { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import {
     createPoint,
+    deletePoint,
     getPoint,
     updatePoint,
     type AdminMapPoint,
 } from '@/admin/lib/adminApi'
+import { ConfirmDialog } from '@/admin/components/ConfirmDialog'
 import { PointForm, type PointFormValue } from '@/admin/components/PointForm'
 import { PhotoManager } from '@/admin/components/PhotoManager'
+import { getUndoRedoShortcuts } from '@/utils/platformShortcuts'
 
 interface PointEditPageProps {
     mode: 'create' | 'edit'
@@ -42,6 +45,9 @@ export function PointEditPage({ mode }: PointEditPageProps) {
 
     const [initial, setInitial] = useState<PointFormValue | null>(mode === 'create' ? DEFAULT_VALUE : null)
     const [error, setError] = useState<string | null>(null)
+    const [confirmDelete, setConfirmDelete] = useState(false)
+    const [deleting, setDeleting] = useState(false)
+    const shortcuts = getUndoRedoShortcuts()
 
     useEffect(() => {
         if (mode !== 'edit' || pointId === null) return
@@ -69,21 +75,50 @@ export function PointEditPage({ mode }: PointEditPageProps) {
         }
     }
 
+    const handleDelete = async () => {
+        if (pointId === null) return
+        setDeleting(true)
+        try {
+            await deletePoint(pointId)
+            await navigate('/admin/points')
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setDeleting(false)
+            setConfirmDelete(false)
+        }
+    }
+
     return (
-        <section className="max-w-3xl">
+        <section className="w-full max-w-none">
             <header className="mb-4">
                 <h1 className="text-xl font-semibold">
                     {mode === 'create' ? 'Новая точка' : `Точка #${params.id ?? ''}`}
                 </h1>
                 <p className="mt-1 text-sm text-neutral-600">
-                    Заполните поля и сохраните. Координаты — в формате lng, lat.
+                    Шаги отменяются {shortcuts.undo} и повторяются {shortcuts.redo} (вне полей ввода).
                 </p>
+                {mode === 'edit' && pointId !== null && (
+                    <div className="mt-3">
+                        <button
+                            type="button"
+                            disabled={deleting}
+                            onClick={() => {
+                                setConfirmDelete(true)
+                            }}
+                            className="rounded-lg border border-red-200 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
+                        >
+                            Удалить точку
+                        </button>
+                    </div>
+                )}
             </header>
 
             {error && <div className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
 
             {initial ? (
                 <PointForm
+                    key={mode === 'edit' && pointId !== null ? String(pointId) : 'create'}
                     initial={initial}
                     submitLabel={mode === 'create' ? 'Создать' : 'Сохранить'}
                     onSubmit={handleSubmit}
@@ -100,6 +135,20 @@ export function PointEditPage({ mode }: PointEditPageProps) {
                     <PhotoManager pointId={pointId} />
                 </div>
             )}
+
+            <ConfirmDialog
+                open={confirmDelete}
+                title="Удалить точку?"
+                description="Будет удалена точка и все связанные с ней фото. Действие необратимо."
+                confirmLabel="Удалить"
+                danger
+                onCancel={() => {
+                    if (!deleting) setConfirmDelete(false)
+                }}
+                onConfirm={() => {
+                    void handleDelete()
+                }}
+            />
         </section>
     )
 }

--- a/src/hooks/useMapbox.ts
+++ b/src/hooks/useMapbox.ts
@@ -97,6 +97,23 @@ export function useMapbox(containerRef: React.RefObject<HTMLDivElement | null>) 
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: init once
   }, []);
 
+  useEffect(() => {
+    if (!map) {
+      return;
+    }
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const ro = new ResizeObserver(() => {
+      map.resize();
+    });
+    ro.observe(container);
+    return () => {
+      ro.disconnect();
+    };
+  }, [map, containerRef]);
+
   const setBaseMapStyle = useCallback((style: BaseMapStyle) => {
     setBaseStyle(style);
     try {

--- a/src/index.css
+++ b/src/index.css
@@ -30,6 +30,16 @@
   overflow: hidden;
 }
 
+/* Карта в админке: растягивается в flex-колонке справа; минимальная высота задаётся в разметке */
+.admin-editor-map {
+  position: relative;
+  box-sizing: border-box;
+  width: 100%;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
 /* Паддинги контейнера с учётом safe-area (для полноэкранных модалок) */
 .safe-area-padding {
   padding-top: max(1rem, env(safe-area-inset-top));


### PR DESCRIPTION
## Summary
- add admin point map component and wire point form to map-based coordinate editing
- add coordinate undo/redo handling and platform-aware shortcut text in point editor UI
- update map container resize behavior and admin map styles for split-layout editing

## Test plan
- [x] npm run lint
- [x] npm run build

Made with [Cursor](https://cursor.com)