### PR TITLE
feat: cache Mapbox tiles in service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -11,7 +11,9 @@ const APP_SHELL = [
 const HOME_FALLBACK = `${BASE_PATH}`;
 const STATIC_ASSET_CACHE = `${CACHE_VERSION}-static`;
 const RUNTIME_CACHE = `${CACHE_VERSION}-runtime`;
+const TILE_CACHE = `${CACHE_VERSION}-tiles`;
 const MAX_RUNTIME_ENTRIES = 120;
+const MAX_TILE_ENTRIES = 500;
 
 function isHttpRequest(url) {
   return url.protocol === 'http:' || url.protocol === 'https:';
@@ -49,6 +51,19 @@ function isSupabaseRealtimeOrApiRequest(requestUrl) {
     pathname.includes('/auth/v1') ||
     pathname.includes('/storage/v1')
   );
+}
+
+// Кэшируем тайлы, шрифты, спрайты и стили с api.mapbox.com.
+// Исключаем события/телеметрию (events.mapbox.com и /events/).
+function isMapboxTileRequest(requestUrl) {
+  const { hostname, pathname } = requestUrl;
+  if (hostname === 'api.mapbox.com') {
+    return !pathname.startsWith('/events/');
+  }
+  if (hostname.endsWith('.tiles.mapbox.com')) {
+    return true;
+  }
+  return false;
 }
 
 async function trimRuntimeCache(cacheName, maxEntries) {
@@ -94,13 +109,31 @@ async function handleAppAssetRequest(request) {
   return response;
 }
 
+// Cache-first: тайлы иммутабельны для данного URL, потому сначала отдаём из кэша.
+async function handleTileRequest(request) {
+  const cache = await caches.open(TILE_CACHE);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+
+  try {
+    const response = await fetch(request);
+    if (response.ok) {
+      await cache.put(request, response.clone());
+      await trimRuntimeCache(TILE_CACHE, MAX_TILE_ENTRIES);
+    }
+    return response;
+  } catch {
+    return Response.error();
+  }
+}
+
 async function handleInstall() {
   const cache = await caches.open(STATIC_ASSET_CACHE);
   await cache.addAll(APP_SHELL);
 }
 
 async function handleActivate() {
-  await cleanupOutdatedCaches(new Set([STATIC_ASSET_CACHE, RUNTIME_CACHE]));
+  await cleanupOutdatedCaches(new Set([STATIC_ASSET_CACHE, RUNTIME_CACHE, TILE_CACHE]));
   await self.clients.claim();
 }
 
@@ -125,6 +158,11 @@ self.addEventListener('fetch', (event) => {
 
   // Никогда не кэшируем Supabase API/realtime запросы.
   if (isSupabaseRealtimeOrApiRequest(requestUrl)) {
+    return;
+  }
+
+  if (isMapboxTileRequest(requestUrl)) {
+    event.respondWith(handleTileRequest(request));
     return;
   }
 


### PR DESCRIPTION
## What changed

Added a dedicated **tile cache** to the service worker (`public/sw.js`) for Mapbox map resources.

**Strategy: cache-first** — tile URLs are immutable per `{z}/{x}/{y}`, so if a tile is in cache it's served instantly without a network request.

**What gets cached:**
- `api.mapbox.com` — vector tiles, style JSON, font glyphs (PBF), sprites
- `*.tiles.mapbox.com` — Mapbox CDN tile servers

**What is excluded:**
- `api.mapbox.com/events/` — Mapbox telemetry/analytics (intentionally not cached)
- `events.mapbox.com` — already not matched by the hostname check

**Implementation details:**
- New `TILE_CACHE = map-euc-{version}-tiles` cache, isolated from static and runtime caches
- `MAX_TILE_ENTRIES = 500` — oldest entries evicted when limit is reached (reuses existing `trimRuntimeCache`)
- `TILE_CACHE` added to `handleActivate` cleanup set, so old tile caches are deleted on SW version update

## Why

Previously all Mapbox tile requests were fetched fresh on every map pan/zoom. With this change:
- Revisited areas load instantly from cache
- Map works offline for previously viewed areas
- Bandwidth usage is reduced significantly