### PR TITLE
Улучшение интеграции Яндекс.Метрики: SPA-трекинг и цели

### DIFF
--- a/src/components/PwaPrompts.test.tsx
+++ b/src/components/PwaPrompts.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { PwaPrompts } from './PwaPrompts'
+
+const { trackGoalMock, isStandaloneLaunchMock } = vi.hoisted(() => ({
+    trackGoalMock: vi.fn(),
+    isStandaloneLaunchMock: vi.fn(() => false),
+}))
+vi.mock('@/lib/analytics', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/lib/analytics')>()
+    return { ...actual, trackGoal: trackGoalMock, isStandaloneLaunch: isStandaloneLaunchMock }
+})
+
+beforeEach(() => {
+    trackGoalMock.mockClear()
+    isStandaloneLaunchMock.mockReturnValue(false)
+})
+
+describe('PwaPrompts — цель pwa_install', () => {
+    it('шлёт pwa_install на событие appinstalled', () => {
+        render(<PwaPrompts />)
+        window.dispatchEvent(new Event('appinstalled'))
+        expect(trackGoalMock).toHaveBeenCalledWith('pwa_install')
+    })
+
+    it('снимает слушатель при размонтировании', () => {
+        const { unmount } = render(<PwaPrompts />)
+        unmount()
+        window.dispatchEvent(new Event('appinstalled'))
+        expect(trackGoalMock).not.toHaveBeenCalledWith('pwa_install')
+    })
+})
+
+describe('PwaPrompts — цель pwa_launch_standalone', () => {
+    it('шлёт pwa_launch_standalone при запуске из standalone', () => {
+        isStandaloneLaunchMock.mockReturnValue(true)
+        render(<PwaPrompts />)
+        expect(trackGoalMock).toHaveBeenCalledWith('pwa_launch_standalone')
+    })
+
+    it('не шлёт при запуске в обычной вкладке', () => {
+        isStandaloneLaunchMock.mockReturnValue(false)
+        render(<PwaPrompts />)
+        expect(trackGoalMock).not.toHaveBeenCalledWith('pwa_launch_standalone')
+    })
+})

--- a/src/components/PwaPrompts.tsx
+++ b/src/components/PwaPrompts.tsx
@@ -1,7 +1,28 @@
 import { useEffect, useState } from 'react'
+import { isStandaloneLaunch, trackGoal } from '@/lib/analytics'
 
 export function PwaPrompts() {
     const [waitingWorker, setWaitingWorker] = useState<ServiceWorker | null>(null)
+
+    // Цель установки PWA: событие appinstalled срабатывает один раз при установке
+    // приложения (любым способом — кнопка браузера, меню «На экран “Домой”»).
+    useEffect(() => {
+        const onAppInstalled = () => {
+            trackGoal('pwa_install')
+        }
+        window.addEventListener('appinstalled', onAppInstalled)
+        return () => {
+            window.removeEventListener('appinstalled', onAppInstalled)
+        }
+    }, [])
+
+    // Цель запуска установленной PWA: считаем факт открытия из standalone-режима.
+    // Нужно отдельно от appinstalled — на iOS события установки нет, и это единственный сигнал.
+    useEffect(() => {
+        if (isStandaloneLaunch()) {
+            trackGoal('pwa_launch_standalone')
+        }
+    }, [])
 
     useEffect(() => {
         if (!('serviceWorker' in navigator)) return

--- a/src/components/ShareBlock.tsx
+++ b/src/components/ShareBlock.tsx
@@ -14,6 +14,7 @@ import {
     getCoordinatesArray,
     copyOrShare,
 } from '@/utils/shareLinks'
+import { trackGoal } from '@/lib/analytics'
 import type { Feature } from '@/types/geojson'
 
 interface ShareBlockProps {
@@ -145,6 +146,7 @@ export function ShareBlock({ feature, onCopied }: ShareBlockProps) {
     const handleAppShare = useCallback(async () => {
         const ok = await copyOrShare(appUrl, feature.properties.name)
         if (ok) {
+            trackGoal('share_app_link', { featureType: type })
             if (toastTimeoutRef.current) clearTimeout(toastTimeoutRef.current)
             setShowCopied(true)
             toastTimeoutRef.current = setTimeout(() => {
@@ -152,7 +154,7 @@ export function ShareBlock({ feature, onCopied }: ShareBlockProps) {
             }, TOAST_DURATION_MS)
             onCopied?.()
         }
-    }, [appUrl, feature.properties.name, onCopied])
+    }, [appUrl, feature.properties.name, onCopied, type])
 
     useEffect(
         () => () => {
@@ -176,6 +178,9 @@ export function ShareBlock({ feature, onCopied }: ShareBlockProps) {
                             }
                             target="_blank"
                             rel="noopener noreferrer"
+                            onClick={() => {
+                                trackGoal('share_external_map', { provider: 'yandex', featureType: type })
+                            }}
                             className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-neutral-100 text-neutral-600 hover:bg-red-50 hover:text-red-600 transition-colors"
                             title="Яндекс.Карты"
                         >
@@ -189,6 +194,9 @@ export function ShareBlock({ feature, onCopied }: ShareBlockProps) {
                             }
                             target="_blank"
                             rel="noopener noreferrer"
+                            onClick={() => {
+                                trackGoal('share_external_map', { provider: '2gis', featureType: type })
+                            }}
                             className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-neutral-100 text-neutral-600 hover:bg-blue-50 hover:text-blue-600 transition-colors"
                             title="2GIS"
                         >
@@ -197,6 +205,9 @@ export function ShareBlock({ feature, onCopied }: ShareBlockProps) {
                         {(type === 'point' || type === 'socket') && coords && (
                             <a
                                 href={buildGuruPointLink(coords.lat, coords.lon)}
+                                onClick={() => {
+                                    trackGoal('share_external_map', { provider: 'guru', featureType: type })
+                                }}
                                 className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-neutral-100 text-neutral-600 hover:bg-neutral-200 hover:text-neutral-800 transition-colors"
                                 title="Guru"
                             >
@@ -209,6 +220,9 @@ export function ShareBlock({ feature, onCopied }: ShareBlockProps) {
                     <>
                         <a
                             href={buildGuruRouteLink(coordsArray, routeViaCoordinates)}
+                            onClick={() => {
+                                trackGoal('share_external_map', { provider: 'guru', featureType: type })
+                            }}
                             className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-neutral-100 text-neutral-600 hover:bg-neutral-200 hover:text-neutral-800 transition-colors"
                             title="Guru (маршрут)"
                         >
@@ -218,6 +232,9 @@ export function ShareBlock({ feature, onCopied }: ShareBlockProps) {
                             href={buildOpenRouteLink(coordsArray, routeViaCoordinates)}
                             target="_blank"
                             rel="noopener noreferrer"
+                            onClick={() => {
+                                trackGoal('share_external_map', { provider: 'openroute', featureType: type })
+                            }}
                             className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-neutral-100 text-neutral-600 hover:bg-green-50 hover:text-green-600 transition-colors"
                             title="OpenRouteService"
                         >
@@ -230,6 +247,9 @@ export function ShareBlock({ feature, onCopied }: ShareBlockProps) {
                         href={telegramShareLink}
                         target="_blank"
                         rel="noopener noreferrer"
+                        onClick={() => {
+                            trackGoal('share_telegram', { featureType: type })
+                        }}
                         className="inline-flex items-center justify-center w-10 h-10 rounded-lg bg-neutral-100 text-neutral-600 hover:bg-sky-50 hover:text-sky-600 transition-colors"
                         title="Поделиться в Telegram"
                     >

--- a/src/components/YandexMetrika.tsx
+++ b/src/components/YandexMetrika.tsx
@@ -1,17 +1,26 @@
 import { MetrikaCounter } from 'react-metrika'
+import { useLocation } from 'react-router-dom'
+import { isAdminPath, metrikaCounterId } from '@/lib/analytics'
+import { useMetrikaPageViews } from '@/hooks/useMetrikaPageViews'
 
-const rawId = import.meta.env.VITE_YANDEX_METRIKA_ID?.trim()
-const counterId = rawId && rawId.length > 0 ? Number.parseInt(rawId, 10) : Number.NaN
-
-/** Счётчик Метрики через пакет react-metrika; без VITE_YANDEX_METRIKA_ID не рендерится. */
+/**
+ * Счётчик Метрики через пакет react-metrika.
+ * Не рендерится без VITE_YANDEX_METRIKA_ID и в админ-зоне (`/admin/*`) —
+ * чтобы не считать служебный трафик и не писать webvisor по админке.
+ */
 export function YandexMetrika() {
-    if (!Number.isFinite(counterId) || counterId <= 0) {
+    // Хуки вызываем всегда (до раннего return) — иначе нарушим правила хуков.
+    // trackPageView внутри сам no-op, если счётчик не подключён или путь — админский.
+    useMetrikaPageViews()
+    const { pathname } = useLocation()
+
+    if (metrikaCounterId === null || isAdminPath(pathname)) {
         return null
     }
 
     return (
         <MetrikaCounter
-            id={counterId}
+            id={metrikaCounterId}
             options={{
                 accurateTrackBounce: true,
                 childIframe: false,

--- a/src/hooks/useGeolocateControl.test.ts
+++ b/src/hooks/useGeolocateControl.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { Map as MapboxMap } from 'mapbox-gl'
+import { useGeolocateControl } from './useGeolocateControl'
+
+const { trackGoalMock } = vi.hoisted(() => ({ trackGoalMock: vi.fn() }))
+vi.mock('@/lib/analytics', () => ({ trackGoal: trackGoalMock }))
+
+/** Перехватывает обработчики, переданные в geolocate.on(...), чтобы дёргать их в тесте. */
+let handlers: Map<string, (arg?: unknown) => void> = new Map()
+
+vi.mock('mapbox-gl', () => {
+    class GeolocateControl {
+        on(event: string, cb: (arg?: unknown) => void) {
+            handlers.set(event, cb)
+        }
+        off() {
+            /* noop */
+        }
+    }
+    return { default: { GeolocateControl } }
+})
+
+/** Вызывает перехваченный обработчик события; падает, если он не зарегистрирован. */
+function fire(event: string, arg?: unknown): void {
+    const handler = handlers.get(event)
+    if (!handler) throw new Error(`Обработчик "${event}" не зарегистрирован`)
+    handler(arg)
+}
+
+function makeMap(): MapboxMap {
+    return {
+        addControl: vi.fn(),
+        removeControl: vi.fn(),
+    } as unknown as MapboxMap
+}
+
+beforeEach(() => {
+    trackGoalMock.mockClear()
+    handlers = new Map()
+})
+
+describe('useGeolocateControl — цели геолокации', () => {
+    it('шлёт geolocation_success при первом успехе', () => {
+        renderHook(() => useGeolocateControl(makeMap(), true))
+        fire('geolocate')
+        expect(trackGoalMock).toHaveBeenCalledWith('geolocation_success')
+    })
+
+    it('не дублирует geolocation_success при повторных событиях geolocate', () => {
+        renderHook(() => useGeolocateControl(makeMap(), true))
+        fire('geolocate')
+        fire('geolocate')
+        fire('geolocate')
+        expect(trackGoalMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('шлёт geolocation_denied при отказе в доступе', () => {
+        renderHook(() => useGeolocateControl(makeMap(), true))
+        fire('error', { code: 1, PERMISSION_DENIED: 1 })
+        expect(trackGoalMock).toHaveBeenCalledWith('geolocation_denied')
+    })
+
+    it('не шлёт geolocation_denied при прочих ошибках', () => {
+        renderHook(() => useGeolocateControl(makeMap(), true))
+        fire('error', { code: 3, PERMISSION_DENIED: 1, TIMEOUT: 3 })
+        expect(trackGoalMock).not.toHaveBeenCalled()
+    })
+})

--- a/src/hooks/useGeolocateControl.ts
+++ b/src/hooks/useGeolocateControl.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import mapboxgl from 'mapbox-gl'
 import type { Map as MapboxMap } from 'mapbox-gl'
+import { trackGoal } from '@/lib/analytics'
 
 function geolocationErrorMessage(error: GeolocationPositionError): string {
     if (error.code === error.PERMISSION_DENIED) {
@@ -18,6 +19,9 @@ function geolocationErrorMessage(error: GeolocationPositionError): string {
  */
 export function useGeolocateControl(map: MapboxMap | null, isMapReady: boolean) {
     const [locationErrorMessage, setLocationErrorMessage] = useState<string | null>(null)
+    // Цель geolocation_success шлём один раз за сессию: при трекинге событие geolocate
+    // приходит на каждое обновление позиции, нам же важен сам факт успешной геолокации.
+    const geolocateGoalSentRef = useRef(false)
 
     useEffect(() => {
         if (!map || !isMapReady) {
@@ -39,10 +43,17 @@ export function useGeolocateControl(map: MapboxMap | null, isMapReady: boolean) 
 
         const onGeolocate = () => {
             setLocationErrorMessage(null)
+            if (!geolocateGoalSentRef.current) {
+                geolocateGoalSentRef.current = true
+                trackGoal('geolocation_success')
+            }
         }
 
         const onError = (e: GeolocationPositionError) => {
             setLocationErrorMessage(geolocationErrorMessage(e))
+            if (e.code === e.PERMISSION_DENIED) {
+                trackGoal('geolocation_denied')
+            }
         }
 
         const onOutOfMaxBounds = () => {

--- a/src/hooks/useMapFeatureSelection.ts
+++ b/src/hooks/useMapFeatureSelection.ts
@@ -5,6 +5,7 @@ import { LAYER_IDS, LAYER_ID_TO_SOURCE, MAP_ZOOM_FOCUS } from '@/constants'
 import { getFeatureBounds, getFeatureCenter } from '@/utils/bounds'
 import type { SelectedFeatureState } from '@/utils/selectionOpacity'
 import { computeMapPadding } from '@/hooks/useMapPadding'
+import { trackGoal } from '@/lib/analytics'
 
 type PaddingRect = { top: number; right: number; bottom: number; left: number }
 
@@ -65,6 +66,7 @@ export function useMapFeatureSelection(params: {
             }
             setSelectedFeatureState(sourceId ? { sourceId, id } : null)
             setSelectedFeature(feature)
+            trackGoal('feature_open', { featureType: feature.properties.type })
         },
         [flyTo, flyToBounds],
     )

--- a/src/hooks/useMetrikaPageViews.test.tsx
+++ b/src/hooks/useMetrikaPageViews.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom'
+import { useEffect } from 'react'
+import { useMetrikaPageViews } from './useMetrikaPageViews'
+
+const { trackPageViewMock } = vi.hoisted(() => ({ trackPageViewMock: vi.fn() }))
+vi.mock('@/lib/analytics', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('@/lib/analytics')>()
+    return { ...actual, trackPageView: trackPageViewMock }
+})
+
+/** Компонент, подключающий хук и навигирующий по заданным путям после монтирования. */
+function Harness({ navigateTo }: { navigateTo?: string[] }) {
+    useMetrikaPageViews()
+    const navigate = useNavigate()
+    useEffect(() => {
+        navigateTo?.forEach((path) => {
+            void navigate(path)
+        })
+    }, [navigate, navigateTo])
+    return null
+}
+
+function renderAt(initial: string, navigateTo?: string[]) {
+    return render(
+        <MemoryRouter initialEntries={[initial]}>
+            <Routes>
+                <Route path="*" element={<Harness navigateTo={navigateTo} />} />
+            </Routes>
+        </MemoryRouter>,
+    )
+}
+
+beforeEach(() => {
+    trackPageViewMock.mockClear()
+})
+
+describe('useMetrikaPageViews', () => {
+    it('не шлёт hit на первый рендер', () => {
+        renderAt('/')
+        expect(trackPageViewMock).not.toHaveBeenCalled()
+    })
+
+    it('шлёт hit на переход по SPA', () => {
+        renderAt('/', ['/events'])
+        expect(trackPageViewMock).toHaveBeenCalledWith('/events')
+    })
+
+    it('передаёт search и hash в url', () => {
+        renderAt('/', ['/m/point/11?focus=1'])
+        expect(trackPageViewMock).toHaveBeenCalledWith('/m/point/11?focus=1')
+    })
+
+    it('не шлёт hit на переход в админку', () => {
+        renderAt('/', ['/admin/points'])
+        expect(trackPageViewMock).not.toHaveBeenCalled()
+    })
+})

--- a/src/hooks/useMetrikaPageViews.ts
+++ b/src/hooks/useMetrikaPageViews.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef } from 'react'
+import { useLocation } from 'react-router-dom'
+import { isAdminPath, trackPageView } from '@/lib/analytics'
+
+/**
+ * Отправляет в Метрику виртуальный просмотр (`hit`) на каждое изменение пути SPA.
+ * Первый рендер пропускается — стартовый просмотр Метрика фиксирует сама при init.
+ * Маршруты админки (`/admin/*`) не трекаются.
+ */
+export function useMetrikaPageViews(): void {
+    const location = useLocation()
+    const url = `${location.pathname}${location.search}${location.hash}`
+    const isFirstRender = useRef(true)
+
+    useEffect(() => {
+        if (isFirstRender.current) {
+            isFirstRender.current = false
+            return
+        }
+        if (isAdminPath(location.pathname)) return
+        trackPageView(url)
+    }, [url, location.pathname])
+}

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const ymMock = vi.fn()
+vi.mock('react-metrika', () => ({ ym: ymMock }))
+
+/** Перезагружает модуль analytics с заданным значением VITE_YANDEX_METRIKA_ID. */
+async function loadAnalytics(counterId: string | undefined) {
+    vi.resetModules()
+    if (counterId === undefined) {
+        vi.stubEnv('VITE_YANDEX_METRIKA_ID', '')
+    } else {
+        vi.stubEnv('VITE_YANDEX_METRIKA_ID', counterId)
+    }
+    return import('./analytics')
+}
+
+beforeEach(() => {
+    ymMock.mockClear()
+})
+
+afterEach(() => {
+    vi.unstubAllEnvs()
+})
+
+describe('metrikaCounterId / isMetrikaEnabled', () => {
+    it('парсит валидный id', async () => {
+        const a = await loadAnalytics('12345')
+        expect(a.metrikaCounterId).toBe(12345)
+        expect(a.isMetrikaEnabled).toBe(true)
+    })
+
+    it('даёт null при пустой переменной', async () => {
+        const a = await loadAnalytics(undefined)
+        expect(a.metrikaCounterId).toBeNull()
+        expect(a.isMetrikaEnabled).toBe(false)
+    })
+
+    it('даёт null при некорректном/неположительном значении', async () => {
+        expect((await loadAnalytics('abc')).metrikaCounterId).toBeNull()
+        expect((await loadAnalytics('0')).metrikaCounterId).toBeNull()
+        expect((await loadAnalytics('-5')).metrikaCounterId).toBeNull()
+    })
+})
+
+describe('isAdminPath', () => {
+    it('распознаёт админские пути', async () => {
+        const { isAdminPath } = await loadAnalytics('1')
+        expect(isAdminPath('/admin')).toBe(true)
+        expect(isAdminPath('/admin/points')).toBe(true)
+        expect(isAdminPath('/admin/route/5')).toBe(true)
+    })
+
+    it('не считает публичные пути админскими', async () => {
+        const { isAdminPath } = await loadAnalytics('1')
+        expect(isAdminPath('/')).toBe(false)
+        expect(isAdminPath('/events')).toBe(false)
+        expect(isAdminPath('/m/point/11')).toBe(false)
+        expect(isAdminPath('/administrator')).toBe(false)
+    })
+})
+
+describe('isStandaloneLaunch', () => {
+    function stubMatchMedia(standalone: boolean) {
+        vi.stubGlobal('matchMedia', (query: string) => ({
+            matches: query === '(display-mode: standalone)' ? standalone : false,
+        }))
+    }
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        Reflect.deleteProperty(navigator, 'standalone')
+    })
+
+    it('true при display-mode: standalone', async () => {
+        stubMatchMedia(true)
+        const { isStandaloneLaunch } = await loadAnalytics('1')
+        expect(isStandaloneLaunch()).toBe(true)
+    })
+
+    it('true при iOS navigator.standalone', async () => {
+        stubMatchMedia(false)
+        Object.defineProperty(navigator, 'standalone', { value: true, configurable: true })
+        const { isStandaloneLaunch } = await loadAnalytics('1')
+        expect(isStandaloneLaunch()).toBe(true)
+    })
+
+    it('false в обычной вкладке браузера', async () => {
+        stubMatchMedia(false)
+        const { isStandaloneLaunch } = await loadAnalytics('1')
+        expect(isStandaloneLaunch()).toBe(false)
+    })
+})
+
+describe('trackPageView', () => {
+    it('шлёт hit при подключённом счётчике', async () => {
+        const { trackPageView } = await loadAnalytics('777')
+        trackPageView('/events')
+        expect(ymMock).toHaveBeenCalledWith(777, 'hit', '/events')
+    })
+
+    it('no-op без счётчика', async () => {
+        const { trackPageView } = await loadAnalytics(undefined)
+        trackPageView('/events')
+        expect(ymMock).not.toHaveBeenCalled()
+    })
+
+    it('не пробрасывает ошибку счётчика', async () => {
+        ymMock.mockImplementationOnce(() => {
+            throw new Error('boom')
+        })
+        const { trackPageView } = await loadAnalytics('1')
+        expect(() => {
+            trackPageView('/x')
+        }).not.toThrow()
+    })
+})
+
+describe('trackGoal', () => {
+    it('шлёт reachGoal c параметрами', async () => {
+        const { trackGoal } = await loadAnalytics('42')
+        trackGoal('feature_open', { featureType: 'route' })
+        expect(ymMock).toHaveBeenCalledWith(42, 'reachGoal', 'feature_open', { featureType: 'route' })
+    })
+
+    it('no-op без счётчика', async () => {
+        const { trackGoal } = await loadAnalytics(undefined)
+        trackGoal('share_app_link')
+        expect(ymMock).not.toHaveBeenCalled()
+    })
+
+    it('не пробрасывает ошибку счётчика', async () => {
+        ymMock.mockImplementationOnce(() => {
+            throw new Error('boom')
+        })
+        const { trackGoal } = await loadAnalytics('1')
+        expect(() => {
+            trackGoal('share_telegram')
+        }).not.toThrow()
+    })
+})

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,68 @@
+import { ym } from 'react-metrika'
+
+const rawId = import.meta.env.VITE_YANDEX_METRIKA_ID?.trim()
+const parsedId = rawId && rawId.length > 0 ? Number.parseInt(rawId, 10) : Number.NaN
+
+/** ID счётчика Метрики или null, если переменная не задана/некорректна. */
+export const metrikaCounterId: number | null = Number.isFinite(parsedId) && parsedId > 0 ? parsedId : null
+
+/** Подключена ли Метрика (есть валидный counter id). */
+export const isMetrikaEnabled = metrikaCounterId !== null
+
+/**
+ * Путь относится к админ-панели (`/admin` и вложенные).
+ * В админке Метрику не считаем: это служебная зона, не продуктовый трафик,
+ * и сюда не должна попадать запись webvisor.
+ */
+export function isAdminPath(pathname: string): boolean {
+    return pathname === '/admin' || pathname.startsWith('/admin/')
+}
+
+/**
+ * Приложение запущено как установленная PWA (standalone).
+ * Покрывает оба способа: стандартный `display-mode: standalone` (Chrome/Android/desktop)
+ * и проприетарный `navigator.standalone` (iOS Safari, где нет события appinstalled).
+ */
+export function isStandaloneLaunch(): boolean {
+    if (typeof window === 'undefined') return false
+    const byMediaQuery = window.matchMedia('(display-mode: standalone)').matches
+    const iosStandalone = (navigator as Navigator & { standalone?: boolean }).standalone === true
+    return byMediaQuery || iosStandalone
+}
+
+/** Допустимые цели (reachGoal). Держим список здесь — единый источник имён. */
+export type MetrikaGoal =
+    | 'feature_open' // открыта фича на карте (точка/маршрут/розетка/велодорожка/telegram)
+    | 'share_app_link' // скопирована/расшарена ссылка на приложение
+    | 'share_external_map' // переход во внешнюю карту/навигатор (Яндекс/2GIS/Guru/ORS)
+    | 'share_telegram' // шаринг в Telegram
+    | 'pwa_install' // приложение установлено как PWA (событие appinstalled)
+    | 'pwa_launch_standalone' // запуск в standalone-режиме (установленная PWA, в т.ч. iOS)
+    | 'geolocation_success' // пользователь успешно определил свою геопозицию
+    | 'geolocation_denied' // доступ к геопозиции отклонён пользователем
+
+/**
+ * Регистрирует SPA-переход (виртуальный просмотр страницы).
+ * No-op, если Метрика не подключена. Ошибки счётчика не пробрасываются.
+ */
+export function trackPageView(url: string): void {
+    if (metrikaCounterId === null) return
+    try {
+        ym(metrikaCounterId, 'hit', url)
+    } catch {
+        // Метрика не должна влиять на работу приложения
+    }
+}
+
+/**
+ * Отправляет достижение цели в Метрику. No-op без подключённого счётчика.
+ * Ошибки счётчика глушатся — аналитика не критична для UX.
+ */
+export function trackGoal(goal: MetrikaGoal, params?: Record<string, unknown>): void {
+    if (metrikaCounterId === null) return
+    try {
+        ym(metrikaCounterId, 'reachGoal', goal, params)
+    } catch {
+        // Метрика не должна влиять на работу приложения
+    }
+}


### PR DESCRIPTION
## Summary
Улучшена интеграция Яндекс.Метрики — корректный учёт SPA-навигации и продуктовые цели.

- **Централизованный хелпер** `src/lib/analytics.ts`: `trackGoal(goal, params?)` и `trackPageView(url)`. Обе — no-op без счётчика (`VITE_YANDEX_METRIKA_ID`) и глушат ошибки, чтобы аналитика не влияла на UX. Имена целей — закрытый union `MetrikaGoal`.
- **SPA-трекинг переходов** — хук `useMetrikaPageViews` шлёт `hit` на каждую смену пути (раньше считалась только первая загрузка; переходы по разделам и deep-link'ам терялись).
- **Цели (reachGoal):**
  - `feature_open` — открытие фичи на карте (с `featureType`)
  - `share_app_link`, `share_external_map` (provider: yandex/2gis/guru/openroute), `share_telegram`
  - `pwa_install` — установка PWA (событие `appinstalled`)
  - `pwa_launch_standalone` — запуск установленной PWA, единственный сигнал для iOS (`isStandaloneLaunch()` через `display-mode: standalone` + `navigator.standalone`)
  - `geolocation_success` (раз за сессию), `geolocation_denied` (только `PERMISSION_DENIED`)
- **Отключение в `/admin`**: в админ-зоне не рендерится `<MetrikaCounter>` (нет webvisor по админке) и не шлются pageview. Проверка — `isAdminPath()`.

## Test plan
- [x] `npm run test` passes (350 тестов)
- [x] `npm run build` succeeds
- [x] lint + tsc чистые (прошли pre-commit гейт)
- [ ] Проверить в Метрике поступление целей после деплоя

🤖 Generated with [Claude Code](https://claude.com/claude-code)