### PR TITLE
ci: пропускать Test на push в main для docs-only изменений

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,18 @@
 name: Test
 
 on:
+  # На PR гоняем всегда (merge-гейт). На push в main — пропускаем, если изменения
+  # затронули только не-кодовые файлы (docs/markdown/конфиги редактора): тесты на
+  # этот код уже прошли на PR, повторный прогон на main был бы дублем.
   pull_request:
   push:
     branches: ['main']
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
+      - '.editorconfig'
+      - '.gitignore'
+      - '.vscode/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
После merge PR в `main` Test-workflow прогонялся повторно на `main`, хотя те же изменения уже проверены на PR. Добавлен `paths-ignore` к **push**-триггеру: если merge затронул только не-кодовые файлы — повторный прогон не запускается.

## Поведение
- **push в main** → Test пропускается, если изменения **только** в: `**/*.md`, `LICENSE`, `.editorconfig`, `.gitignore`, `.vscode/**`. Любой код → тесты идут.
- **pull_request** → фильтра нет, PR проверяются всегда (merge-гейт), docs-only PR не зависают в ожидании статуса.

`paths-ignore` срабатывает, только когда push затронул **исключительно** игнорируемые пути, так что код всегда тестируется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)