### PR TITLE
fix: ссылка на событие в Telegram-анонсе ведёт на /events/:id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,11 @@ map.setFeatureState({ source, id }, { selected: true })
 
 ### URL Deep Links
 
-- Формат: `/m/point/11`, `/m/route/5`, `/m/socket/3`, `/m/bikelane/alm1`, `/m/telegramuser/123`
-- Старый hash `#point=11` → автоматически редиректит на путь
-- При построении ссылок: `${import.meta.env.BASE_URL}${buildMapDeepLinkPath(type, id)}` — иначе сломается в prod (`base = /map.euc/`)
+- Формат `/m/:type/:id`: `/m/point/11`, `/m/route/5`, `/m/socket/3`, `/m/bikelane/alm1`, `/m/telegramuser/123` — только для типов фич карты (`HashFeatureType` в `src/utils/hashNav.ts`).
+- **События — отдельный маршрут `/events/:id`** (не `/m/event/:id`!). Строить только через `buildEventDetailPath` из `src/utils/eventLinks.ts`; `event` НЕ входит в `HashFeatureType`, поэтому `buildMapDeepLinkPath`/`/m/...` для события даст битую ссылку (маршрут `/m/:type/:id` не распознает тип и откроет пустую карту). Это касается и edge-функций (Telegram-бот): сегмент `events` стабилен (`EVENTS_PATH_PREFIX`), вписывать строкой.
+- При добавлении нового вида сущности со своей страницей — завести парный `build*Path`/`parse*Pathname` и маршрут в `src/App.tsx`; не переиспользовать `/m/...` вслепую.
+- Старый hash `#point=11` → автоматически редиректит на путь.
+- При построении ссылок: `${import.meta.env.BASE_URL}${buildMapDeepLinkPath(type, id)}` — иначе сломается в prod (`base = /map.euc/`).
 
 ### Constants (`src/constants/index.ts`)
 

--- a/supabase/functions/telegram-location-bot/_pure.test.ts
+++ b/supabase/functions/telegram-location-bot/_pure.test.ts
@@ -62,7 +62,7 @@ Deno.test('buildRsvpKeyboard: callback и deep-link кнопки в одном �
     const kb = buildRsvpKeyboard('abc', 3, 'https://map.euc.kz', 7)
     assertEquals(kb.inline_keyboard[0][0].callback_data, 'rsvp:abc')
     assertEquals(kb.inline_keyboard[0][0].text, 'Участвую (3)')
-    assertEquals(kb.inline_keyboard[0][1].url, 'https://map.euc.kz/m/event/7')
+    assertEquals(kb.inline_keyboard[0][1].url, 'https://map.euc.kz/events/7')
 })
 
 Deno.test('buildAnnouncementHeader: день недели + абсолютное по Алматы + относительный <tg-time>', () => {

--- a/supabase/functions/telegram-location-bot/_pure.ts
+++ b/supabase/functions/telegram-location-bot/_pure.ts
@@ -211,7 +211,9 @@ export function buildRsvpKeyboard(
                     style: 'primary',
                     callback_data: `${RSVP_CALLBACK_PREFIX}${eventDateId}`,
                 },
-                { text: 'map.euc.kz', url: `${mapBaseUrl}/m/event/${String(eventId)}` },
+                // Страница события — каноничный путь /events/:id (см. src/utils/eventLinks.ts),
+                // а НЕ /m/:type/:id (тот формат для точек/маршрутов и тип event не знает).
+                { text: 'map.euc.kz', url: `${mapBaseUrl}/events/${String(eventId)}` },
             ],
         ],
     }


### PR DESCRIPTION
## Summary
Кнопка «map.euc.kz» в RSVP-клавиатуре анонса вела на `/m/event/:id`, и страница события не открывалась — тип `event` не входит в `HashFeatureType`, поэтому маршрут `/m/:type/:id` не распознавал его и показывал пустую карту.

- Исправлено на каноничный путь события `/events/:id` (`src/utils/eventLinks.ts`).
- Зафиксировано правило в `CLAUDE.md` (раздел «URL Deep Links»): события — отдельный маршрут, не `/m/...`.

## Test plan
- [x] `deno test supabase/functions/telegram-location-bot/` — 52 passed
- [x] `npm run lint` + `tsc` чисто
- [x] e2e (pre-commit) — 41 passed
- [x] После деплоя проверить, что кнопка в анонсе открывает страницу события

🤖 Generated with [Claude Code](https://claude.com/claude-code)