### PR TITLE
feat(admin): новости проекта — рассылка в Telegram с правкой и удалением

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [Unreleased] — 2026-06-27
+
+### Added
+
+- Новости проекта: раздел `/admin/news` — создание новости (текст + фото), рассылка в выбранные Telegram-чаты, обновление текста во всех отправленных сообщениях и удаление их из Telegram
+- Edge-сабруты `telegram-location-bot`: `/news-announce`, `/news-announce-edit`, `/news-announce-delete`
+- Миграция: таблица `map_news`, Storage-бакет `map-news-photos`
+
+### Changed
+
+- Исходящие сообщения бота объединены в единую таблицу `telegram_outbound_messages` (переименование `map_event_announcements` + полиморфная привязка `event_date_id` | `news_id`); анонсы событий и новости используют общие helpers (`announceClient`, `listLiveAnnouncements`, `editAnnouncementContent`)
+
 ## [Unreleased] — 2026-06-22
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,8 +185,9 @@ map.setFeatureState({ source, id }, { selected: true })
 
 ### Supabase Backend
 
-- **Таблицы**: `map_points`, `map_routes`, `map_point_photos`, `map_points_submissions`, `telegram_locations`, `telegram_profiles`, `map_admin_users`
-- **Storage**: бакеты `map-point-photos/` и `telegram-avatars/` (публичные URL, без bot-токенов)
+- **Таблицы**: `map_points`, `map_routes`, `map_point_photos`, `map_points_submissions`, `telegram_locations`, `telegram_profiles`, `map_admin_users`, `map_events`, `map_event_dates`, `map_event_participants`, `map_news`, `telegram_chats`, `telegram_outbound_messages`
+- **`telegram_outbound_messages`** — единая таблица исходящих сообщений бота (бывшая `map_event_announcements`, переименована в миграции `20260627120000`). Полиморфная привязка: `event_date_id` (анонс события) ЛИБО `news_id` (новость проекта); CHECK гарантирует ровно один из них. Маппинг `(telegram_chat_id, telegram_message_id)` → отправитель используется для RSVP-callback событий, а также правки/удаления сообщений. Поля `cancelled_at`/`pinned_at` специфичны для событий.
+- **Storage**: бакеты `map-point-photos/`, `telegram-avatars/`, `map-event-photos/`, `map-news-photos/` (публичные URL, без bot-токенов)
 - **RLS**: публичное чтение (кроме disabled/draft); запись требует auth или Edge Function
 - **Resilience**: `withTimeoutAndRetry()` в `lib/supabase.ts`; при отсутствии URL/ключа — fallback на Cache API, предупреждение в консоль, не бросать ошибку при старте
 - **Миграции**: файлы в `supabase/migrations/`. Применять только через `supabase db push` (или CI), **не** через MCP `apply_migration`/`execute_sql` — последний пишет в `schema_migrations` автогенерённый таймстамп, расходящийся с именем файла, и ломает деплой. Если история разошлась — чинить через `supabase migration repair` (правит учёт, не схему), сверять `supabase migration list`. MCP `apply_migration` допустим лишь для разовых проверок на preview-ветке.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,8 @@ import {
     AdminEventsPage,
     AdminEventEditPage,
     AdminTelegramChatsPage,
+    AdminNewsPage,
+    AdminNewsEditPage,
 } from '@/admin/lazyAdminPages'
 
 export default function App() {
@@ -39,6 +41,9 @@ export default function App() {
                     <Route path="event" element={<AdminEventsPage />} />
                     <Route path="event/new" element={<AdminEventEditPage mode="create" />} />
                     <Route path="event/:id" element={<AdminEventEditPage mode="edit" />} />
+                    <Route path="news" element={<AdminNewsPage />} />
+                    <Route path="news/new" element={<AdminNewsEditPage mode="create" />} />
+                    <Route path="news/:id" element={<AdminNewsEditPage mode="edit" />} />
                     <Route path="telegram-chats" element={<AdminTelegramChatsPage />} />
                     <Route path="geo" element={<AdminGeoPage />} />
                     <Route path="*" element={<Navigate to="/admin/submissions" replace />} />

--- a/src/admin/AdminLayout.tsx
+++ b/src/admin/AdminLayout.tsx
@@ -7,6 +7,7 @@ const NAV_ITEMS = [
     { to: 'point', label: 'Точки' },
     { to: 'route', label: 'Маршруты' },
     { to: 'event', label: 'События' },
+    { to: 'news', label: 'Новости' },
     { to: 'telegram-chats', label: 'Telegram-чаты' },
     { to: 'geo', label: 'Гео' },
 ] as const

--- a/src/admin/components/NewsAnnounceManager.tsx
+++ b/src/admin/components/NewsAnnounceManager.tsx
@@ -1,0 +1,209 @@
+import { useCallback, useEffect, useState } from 'react'
+import {
+    announceNews,
+    deleteNewsAnnouncements,
+    editNewsAnnouncements,
+    listNewsAnnouncements,
+    listTelegramChats,
+    type AdminTelegramChat,
+} from '@/admin/lib/adminApi'
+import { NewsMessagesList } from '@/admin/components/NewsMessagesList'
+import { pendingNewsChats } from '@/utils/newsAnnounce'
+
+interface NewsAnnounceManagerProps {
+    newsId: string
+    /** Текст новости из формы — служит для предупреждения о несохранённых правках. */
+    body: string
+    /** true, если в форме есть несохранённые изменения текста/фото. */
+    hasUnsavedChanges: boolean
+}
+
+/**
+ * Блок рассылки новости в Telegram: выбор чатов и отправка, синхронизация текста
+ * во все отправленные сообщения, удаление из Telegram. Текст берётся из самой новости
+ * (редактируется в форме выше), поэтому здесь его не дублируем.
+ */
+export function NewsAnnounceManager({ newsId, body, hasUnsavedChanges }: NewsAnnounceManagerProps) {
+    const [pendingChats, setPendingChats] = useState<AdminTelegramChat[]>([])
+    const [selected, setSelected] = useState<Set<string>>(new Set())
+    const [loadingChats, setLoadingChats] = useState(true)
+    const [sending, setSending] = useState(false)
+    const [editing, setEditing] = useState(false)
+    const [deleting, setDeleting] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+    const [notice, setNotice] = useState<string | null>(null)
+    // Меняется после любой операции — заставляет NewsMessagesList и список чатов перезагрузиться.
+    const [refreshKey, setRefreshKey] = useState(0)
+
+    const loadChats = useCallback(async () => {
+        setLoadingChats(true)
+        try {
+            // Два независимых запроса — параллельно.
+            const [chats, sent] = await Promise.all([listTelegramChats(), listNewsAnnouncements(newsId)])
+            const enabled = chats.filter((c) => c.enabled)
+            // По умолчанию ничего не выбираем, чтобы случайно не разослать.
+            setPendingChats(pendingNewsChats(enabled, sent))
+            setSelected(new Set())
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setLoadingChats(false)
+        }
+    }, [newsId])
+
+    useEffect(() => {
+        void Promise.resolve().then(() => loadChats())
+    }, [loadChats, refreshKey])
+
+    const toggleChat = (destinationId: string) => {
+        setSelected((prev) => {
+            const next = new Set(prev)
+            if (next.has(destinationId)) next.delete(destinationId)
+            else next.add(destinationId)
+            return next
+        })
+    }
+
+    const afterAction = (message: string) => {
+        setNotice(message)
+        setRefreshKey((k) => k + 1)
+    }
+
+    const handleSend = async () => {
+        if (selected.size === 0) return
+        setSending(true)
+        setError(null)
+        setNotice(null)
+        try {
+            const result = await announceNews(newsId, [...selected])
+            const failed = result.failed.length
+            afterAction(
+                failed === 0
+                    ? `Отправлено: ${String(result.sent.length)}.`
+                    : `Отправлено: ${String(result.sent.length)}, с ошибкой: ${String(failed)}.`,
+            )
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setSending(false)
+        }
+    }
+
+    const handleEdit = async () => {
+        setEditing(true)
+        setError(null)
+        setNotice(null)
+        try {
+            const { edited, failed } = await editNewsAnnouncements(newsId)
+            afterAction(
+                failed.length === 0
+                    ? `Обновлено сообщений: ${String(edited)}.`
+                    : `Обновлено: ${String(edited)}, с ошибкой: ${String(failed.length)}.`,
+            )
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setEditing(false)
+        }
+    }
+
+    const handleDelete = async () => {
+        if (!window.confirm('Удалить отправленные сообщения этой новости из всех Telegram-чатов?')) return
+        setDeleting(true)
+        setError(null)
+        setNotice(null)
+        try {
+            const { deleted } = await deleteNewsAnnouncements(newsId)
+            afterAction(`Удалено сообщений: ${String(deleted)}.`)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setDeleting(false)
+        }
+    }
+
+    const busy = sending || editing || deleting
+    const emptyBody = body.trim().length === 0
+
+    return (
+        <div className="rounded-xl border border-neutral-200 bg-white p-4">
+            <h2 className="text-sm font-semibold text-neutral-800">Рассылка в Telegram</h2>
+
+            {hasUnsavedChanges && (
+                <div className="mt-3 rounded-lg bg-amber-50 px-3 py-2 text-sm text-amber-800">
+                    Сначала сохраните изменения текста — рассылка использует сохранённую версию.
+                </div>
+            )}
+            {error && <div className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+            {notice && <div className="mt-3 rounded-lg bg-emerald-50 px-3 py-2 text-sm text-emerald-800">{notice}</div>}
+
+            {/* Отправка в новые чаты. */}
+            <div className="mt-3">
+                <p className="text-xs font-medium text-neutral-700">Отправить в чаты</p>
+                {loadingChats && <p className="mt-1 text-sm text-neutral-500">Загрузка чатов…</p>}
+                {!loadingChats && pendingChats.length === 0 && (
+                    <p className="mt-1 text-sm text-neutral-400">
+                        Новость отправлена во все включённые чаты (или включённых чатов нет).
+                    </p>
+                )}
+                <div className="mt-1 flex flex-col gap-1">
+                    {pendingChats.map((chat) => (
+                        <label key={chat.id} className="flex items-center gap-2 text-sm text-neutral-700">
+                            <input
+                                type="checkbox"
+                                checked={selected.has(chat.id)}
+                                onChange={() => {
+                                    toggleChat(chat.id)
+                                }}
+                                className="h-4 w-4 rounded border-neutral-300 text-blue-600"
+                            />
+                            {chat.title}
+                            <span className="font-mono text-xs text-neutral-400">
+                                {chat.chat_id}
+                                {chat.message_thread_id !== null && ` / ${String(chat.message_thread_id)}`}
+                            </span>
+                        </label>
+                    ))}
+                </div>
+                {pendingChats.length > 0 && (
+                    <button
+                        type="button"
+                        disabled={busy || selected.size === 0 || emptyBody || hasUnsavedChanges}
+                        onClick={() => {
+                            void handleSend()
+                        }}
+                        className="mt-2 cursor-pointer rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:bg-blue-300"
+                    >
+                        {sending ? 'Отправка…' : 'Отправить в выбранные чаты'}
+                    </button>
+                )}
+            </div>
+
+            <NewsMessagesList newsId={newsId} refreshKey={refreshKey} />
+
+            {/* Синхронизация текста и удаление отправленного. */}
+            <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-neutral-100 pt-3">
+                <button
+                    type="button"
+                    disabled={busy || hasUnsavedChanges}
+                    onClick={() => {
+                        void handleEdit()
+                    }}
+                    className="cursor-pointer rounded-lg border border-blue-200 px-3 py-2 text-sm font-medium text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+                >
+                    {editing ? 'Обновление…' : 'Обновить текст во всех отправленных'}
+                </button>
+                <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => {
+                        void handleDelete()
+                    }}
+                    className="cursor-pointer rounded-lg border border-red-200 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
+                >
+                    {deleting ? 'Удаление…' : 'Удалить из Telegram'}
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/src/admin/components/NewsMessagesList.tsx
+++ b/src/admin/components/NewsMessagesList.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useState } from 'react'
+import { listNewsAnnouncements, listTelegramChats, type AdminNewsAnnouncement } from '@/admin/lib/adminApi'
+import { formatDate, formatTime } from '@/utils/eventSchedule'
+
+interface NewsMessagesListProps {
+    newsId: string
+    /** Меняется родителем после отправки/правки/удаления, чтобы перезагрузить список. */
+    refreshKey: number
+}
+
+type NewsMessageStatus = 'live' | 'deleted' | 'failed'
+
+/** Статус сообщения по полям строки (приоритет: ошибка → удалено → живое). */
+function statusOf(a: AdminNewsAnnouncement): NewsMessageStatus {
+    if (a.telegram_message_id === null || a.send_error !== null) return 'failed'
+    if (a.deleted_at !== null) return 'deleted'
+    return 'live'
+}
+
+const STATUS_BADGE: Record<NewsMessageStatus, { label: string; cls: string } | null> = {
+    live: null,
+    deleted: { label: 'Удалено', cls: 'bg-neutral-100 text-neutral-500' },
+    failed: { label: 'Ошибка', cls: 'bg-red-100 text-red-700' },
+}
+
+/** «Когда»: дата+время отправки, иначе создания строки. */
+function sentLabel(a: AdminNewsAnnouncement): string {
+    const iso = a.sent_at ?? a.created_at
+    const d = new Date(iso)
+    if (Number.isNaN(d.getTime())) return ''
+    return `${formatDate(d)}, ${formatTime(d)}`
+}
+
+/** Список отправленных сообщений новости: куда (имя чата), когда и статус. */
+export function NewsMessagesList({ newsId, refreshKey }: NewsMessagesListProps) {
+    const [rows, setRows] = useState<AdminNewsAnnouncement[] | null>(null)
+    const [chatTitles, setChatTitles] = useState<Map<number, string>>(new Map())
+    const [error, setError] = useState<string | null>(null)
+
+    const load = useCallback(async () => {
+        setError(null)
+        try {
+            const [anns, chats] = await Promise.all([listNewsAnnouncements(newsId), listTelegramChats()])
+            setRows(anns)
+            setChatTitles(new Map(chats.map((c) => [c.chat_id, c.title])))
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        }
+    }, [newsId])
+
+    useEffect(() => {
+        void Promise.resolve().then(() => load())
+    }, [load, refreshKey])
+
+    const chatLabel = (chatId: number) => chatTitles.get(chatId) ?? String(chatId)
+
+    return (
+        <div className="mt-3">
+            <p className="text-xs font-medium text-neutral-700">Отправленные сообщения</p>
+            {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+            {rows === null && !error && <p className="mt-1 text-xs text-neutral-500">Загрузка…</p>}
+            {rows !== null && rows.length === 0 && <p className="mt-1 text-xs text-neutral-400">Сообщений ещё нет.</p>}
+            {rows !== null && rows.length > 0 && (
+                <ul className="mt-1 flex flex-col divide-y divide-neutral-100">
+                    {rows.map((a) => {
+                        const status = statusOf(a)
+                        const badge = STATUS_BADGE[status]
+                        return (
+                            <li key={a.id} className="flex items-center justify-between gap-2 py-1.5 text-xs">
+                                <div className="min-w-0">
+                                    <span className="font-medium text-neutral-800">
+                                        {chatLabel(a.telegram_chat_id)}
+                                    </span>
+                                    <span className="ml-2 text-neutral-500">{sentLabel(a)}</span>
+                                    {badge && (
+                                        <span className={`ml-2 rounded px-1.5 py-0.5 ${badge.cls}`}>{badge.label}</span>
+                                    )}
+                                </div>
+                            </li>
+                        )
+                    })}
+                </ul>
+            )}
+        </div>
+    )
+}

--- a/src/admin/components/NewsPhotoManager.tsx
+++ b/src/admin/components/NewsPhotoManager.tsx
@@ -1,0 +1,100 @@
+import { useRef, useState, type ChangeEvent } from 'react'
+import { deleteNewsPhoto, newsPhotoUrl, setNewsPhoto } from '@/admin/lib/adminApi'
+
+interface NewsPhotoManagerProps {
+    newsId: string
+    photoPath: string | null
+    onChange: (nextPath: string | null) => void
+}
+
+/** Одна фотография новости: загрузка, замена, удаление через Supabase Storage. */
+export function NewsPhotoManager({ newsId, photoPath, onChange }: NewsPhotoManagerProps) {
+    const inputRef = useRef<HTMLInputElement | null>(null)
+    const [busy, setBusy] = useState(false)
+    const [error, setError] = useState<string | null>(null)
+
+    const handleFile = async (e: ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0]
+        if (!file) return
+        setBusy(true)
+        setError(null)
+        try {
+            const updated = await setNewsPhoto(newsId, file, photoPath)
+            onChange(updated.photo_path)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setBusy(false)
+            if (inputRef.current) inputRef.current.value = ''
+        }
+    }
+
+    const handleDelete = async () => {
+        if (!photoPath) return
+        setBusy(true)
+        setError(null)
+        try {
+            const updated = await deleteNewsPhoto(newsId, photoPath)
+            onChange(updated.photo_path)
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setBusy(false)
+        }
+    }
+
+    return (
+        <div className="rounded-xl border border-neutral-200 bg-white p-4">
+            <h2 className="text-sm font-semibold text-neutral-800">Фотография</h2>
+            {photoPath ? (
+                <div className="mt-3">
+                    <img
+                        src={newsPhotoUrl(photoPath)}
+                        alt="Фото новости"
+                        className="h-40 w-full max-w-sm rounded-lg object-cover"
+                    />
+                </div>
+            ) : (
+                <p className="mt-2 text-sm text-neutral-500">Фотография не загружена.</p>
+            )}
+
+            {error && <div className="mt-3 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+
+            <div className="mt-3 flex gap-2">
+                <input
+                    ref={inputRef}
+                    type="file"
+                    accept="image/jpeg,image/png,image/webp"
+                    onChange={(e) => {
+                        void handleFile(e)
+                    }}
+                    className="hidden"
+                />
+                <button
+                    type="button"
+                    disabled={busy}
+                    onClick={() => inputRef.current?.click()}
+                    className="cursor-pointer rounded-lg border border-neutral-300 px-3 py-2 text-sm font-medium hover:bg-neutral-100 disabled:opacity-50"
+                >
+                    {photoPath ? 'Заменить фото' : 'Загрузить фото'}
+                </button>
+                {photoPath && (
+                    <button
+                        type="button"
+                        disabled={busy}
+                        onClick={() => {
+                            void handleDelete()
+                        }}
+                        className="cursor-pointer rounded-lg border border-red-200 px-3 py-2 text-sm font-medium text-red-700 hover:bg-red-50 disabled:opacity-50"
+                    >
+                        Удалить фото
+                    </button>
+                )}
+            </div>
+            <p className="mt-2 text-xs text-neutral-400">
+                Фото можно загрузить только после первой отправки — оно подставляется при рассылке. Если новость уже
+                отправлена, замена фото в Telegram не обновится (Telegram не меняет картинку у отправленного сообщения).
+            </p>
+        </div>
+    )
+}

--- a/src/admin/lazyAdminPages.ts
+++ b/src/admin/lazyAdminPages.ts
@@ -45,3 +45,13 @@ export const AdminTelegramChatsPage = lazy(async () => {
     const m = await import('@/admin/pages/TelegramChatsPage')
     return { default: m.TelegramChatsPage }
 })
+
+export const AdminNewsPage = lazy(async () => {
+    const m = await import('@/admin/pages/NewsPage')
+    return { default: m.NewsPage }
+})
+
+export const AdminNewsEditPage = lazy(async () => {
+    const m = await import('@/admin/pages/NewsEditPage')
+    return { default: m.NewsEditPage }
+})

--- a/src/admin/lib/adminApi/announceClient.ts
+++ b/src/admin/lib/adminApi/announceClient.ts
@@ -1,0 +1,25 @@
+import { db } from '@/admin/lib/adminApi/query'
+
+/**
+ * Вызывает сабрут Edge Function telegram-location-bot и возвращает `data`.
+ * `functions.invoke` сам прикладывает Authorization из сессии; сабрут проверяет
+ * членство в `map_admin_users`. При ошибке логирует с контекстом и бросает.
+ * Общий помощник для рассылок событий и новостей.
+ */
+export async function invokeAnnounce(subroute: string, body: Record<string, unknown>): Promise<unknown> {
+    const { data, error } = (await db().functions.invoke(`telegram-location-bot/${subroute}`, { body })) as {
+        data: unknown
+        error: { message: string } | null
+    }
+    if (error) {
+        console.error(`invokeAnnounce(${subroute}):`, error)
+        throw new Error(error.message)
+    }
+    return data
+}
+
+/** Числовое поле из ответа Edge Function (0, если отсутствует/не число). */
+export function numField(data: unknown, field: string): number {
+    const v = (data as Record<string, unknown> | null)?.[field]
+    return typeof v === 'number' ? v : 0
+}

--- a/src/admin/lib/adminApi/constants.ts
+++ b/src/admin/lib/adminApi/constants.ts
@@ -1,2 +1,3 @@
 export const PHOTOS_BUCKET = 'map-point-photos'
 export const EVENT_PHOTOS_BUCKET = 'map-event-photos'
+export const NEWS_PHOTOS_BUCKET = 'map-news-photos'

--- a/src/admin/lib/adminApi/eventAnnouncements.test.ts
+++ b/src/admin/lib/adminApi/eventAnnouncements.test.ts
@@ -191,7 +191,7 @@ describe('listEventAnnouncements', () => {
 
         await listEventAnnouncements(DATE_ID)
 
-        expect(fromTable).toHaveBeenCalledWith('map_event_announcements')
+        expect(fromTable).toHaveBeenCalledWith('telegram_outbound_messages')
         expect(eqFn).toHaveBeenCalledWith('event_date_id', DATE_ID)
         expect(orderFn).toHaveBeenCalledWith('created_at', { ascending: false })
     })

--- a/src/admin/lib/adminApi/eventAnnouncements.ts
+++ b/src/admin/lib/adminApi/eventAnnouncements.ts
@@ -1,33 +1,11 @@
 import type { AdminEventAnnouncement, AdminEventParticipant, AnnounceResult } from '@/admin/lib/adminApi/types'
 import { db, runManyParsed } from '@/admin/lib/adminApi/query'
+import { invokeAnnounce, numField } from '@/admin/lib/adminApi/announceClient'
 import {
     parseAdminEventAnnouncement,
     parseAdminEventParticipant,
     parseAnnounceResult,
 } from '@/admin/lib/adminApi/parsers'
-
-/**
- * Вызывает сабрут Edge Function telegram-location-bot и возвращает `data`.
- * `functions.invoke` сам прикладывает Authorization из сессии; сабрут проверяет
- * членство в `map_admin_users`. При ошибке логирует с контекстом и бросает.
- */
-async function invokeAnnounce(subroute: string, body: Record<string, unknown>): Promise<unknown> {
-    const { data, error } = (await db().functions.invoke(`telegram-location-bot/${subroute}`, { body })) as {
-        data: unknown
-        error: { message: string } | null
-    }
-    if (error) {
-        console.error(`invokeAnnounce(${subroute}):`, error)
-        throw new Error(error.message)
-    }
-    return data
-}
-
-/** Числовое поле из ответа Edge Function (0, если отсутствует/не число). */
-function numField(data: unknown, field: string): number {
-    const v = (data as Record<string, unknown> | null)?.[field]
-    return typeof v === 'number' ? v : 0
-}
 
 /**
  * Отправляет анонс даты события в выбранные назначения (через Edge Function).
@@ -112,7 +90,7 @@ export async function listEventAnnouncements(eventDateId: string): Promise<Admin
     return runManyParsed(
         'listEventAnnouncements',
         db()
-            .from('map_event_announcements')
+            .from('telegram_outbound_messages')
             .select(ANNOUNCEMENT_COLUMNS)
             .eq('event_date_id', eventDateId)
             .order('created_at', { ascending: false }),
@@ -129,7 +107,7 @@ export async function listEventAnnouncementsForDates(eventDateIds: string[]): Pr
     return runManyParsed(
         'listEventAnnouncementsForDates',
         db()
-            .from('map_event_announcements')
+            .from('telegram_outbound_messages')
             .select(ANNOUNCEMENT_COLUMNS)
             .in('event_date_id', eventDateIds)
             .order('created_at', { ascending: false }),

--- a/src/admin/lib/adminApi/index.ts
+++ b/src/admin/lib/adminApi/index.ts
@@ -7,6 +7,9 @@ export type {
     AdminEventDate,
     AdminEventParticipant,
     AdminEventAnnouncement,
+    AdminNews,
+    NewsInput,
+    AdminNewsAnnouncement,
     AnnounceResult,
     AdminTelegramChat,
     TelegramChatInput,
@@ -74,3 +77,21 @@ export {
     updateTelegramChat,
     deleteTelegramChat,
 } from '@/admin/lib/adminApi/telegramChats'
+
+export {
+    listNews,
+    getNews,
+    createNews,
+    updateNews,
+    deleteNews,
+    setNewsPhoto,
+    deleteNewsPhoto,
+    newsPhotoUrl,
+} from '@/admin/lib/adminApi/news'
+
+export {
+    announceNews,
+    editNewsAnnouncements,
+    deleteNewsAnnouncements,
+    listNewsAnnouncements,
+} from '@/admin/lib/adminApi/newsAnnouncements'

--- a/src/admin/lib/adminApi/news.test.ts
+++ b/src/admin/lib/adminApi/news.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runManyParsed, runOneParsed, storageRemove, storageFrom, tableUpdate, fromTable, db } = vi.hoisted(() => {
+    const storageRemove = vi.fn()
+    const storageUpload = vi.fn()
+    const getPublicUrl = vi.fn(() => ({ data: { publicUrl: 'https://cdn/x' } }))
+    const storageFrom = vi.fn(() => ({ remove: storageRemove, upload: storageUpload, getPublicUrl }))
+    const tableUpdate = vi.fn()
+    const fromTable = vi.fn(() => ({ update: tableUpdate }))
+    return {
+        runManyParsed: vi.fn(),
+        runOneParsed: vi.fn(),
+        storageRemove,
+        storageFrom,
+        tableUpdate,
+        fromTable,
+        db: vi.fn(() => ({ from: fromTable, storage: { from: storageFrom } })),
+    }
+})
+
+vi.mock('@/admin/lib/adminApi/query', () => ({
+    db,
+    runManyParsed,
+    runOneParsed,
+}))
+vi.mock('@/admin/lib/adminApi/parsers', () => ({
+    parseAdminNews: (raw: unknown) => raw,
+}))
+
+import { createNews, deleteNews, listNews } from '@/admin/lib/adminApi/news'
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    db.mockReturnValue({ from: fromTable, storage: { from: storageFrom } })
+    fromTable.mockReturnValue({ update: tableUpdate })
+    storageFrom.mockReturnValue({ remove: storageRemove } as never)
+})
+
+describe('listNews', () => {
+    it('читает только не удалённые, новые сверху', async () => {
+        const order = vi.fn()
+        const isFn = vi.fn(() => ({ order }))
+        const select = vi.fn(() => ({ is: isFn }))
+        fromTable.mockReturnValue({ select } as never)
+        runManyParsed.mockResolvedValue([])
+
+        await listNews()
+
+        expect(fromTable).toHaveBeenCalledWith('map_news')
+        expect(isFn).toHaveBeenCalledWith('deleted_at', null)
+        expect(order).toHaveBeenCalledWith('created_at', { ascending: false })
+    })
+})
+
+describe('createNews', () => {
+    it('вставляет тело и возвращает запись', async () => {
+        const single = vi.fn()
+        const select = vi.fn(() => ({ single }))
+        const insert = vi.fn(() => ({ select }))
+        fromTable.mockReturnValue({ insert } as never)
+        runOneParsed.mockResolvedValue({ id: 'n-1' })
+
+        await createNews({ body: 'Привет' })
+
+        expect(insert).toHaveBeenCalledWith({ body: 'Привет' })
+    })
+})
+
+describe('deleteNews', () => {
+    it('мягко удаляет (deleted_at) и удаляет фото из Storage', async () => {
+        const eq = vi.fn().mockResolvedValue({ error: null })
+        tableUpdate.mockReturnValue({ eq })
+        storageRemove.mockResolvedValue({ error: null })
+
+        await deleteNews({ id: 'n-1', photo_path: 'n-1/p.jpg' })
+
+        expect(storageFrom).toHaveBeenCalledWith('map-news-photos')
+        expect(storageRemove).toHaveBeenCalledWith(['n-1/p.jpg'])
+        const payload = tableUpdate.mock.calls[0]?.[0] as { deleted_at?: unknown }
+        expect(typeof payload.deleted_at).toBe('string')
+        expect(eq).toHaveBeenCalledWith('id', 'n-1')
+    })
+
+    it('без фото не трогает Storage', async () => {
+        const eq = vi.fn().mockResolvedValue({ error: null })
+        tableUpdate.mockReturnValue({ eq })
+
+        await deleteNews({ id: 'n-1', photo_path: null })
+
+        expect(storageRemove).not.toHaveBeenCalled()
+    })
+
+    it('бросает ошибку при сбое обновления', async () => {
+        const eq = vi.fn().mockResolvedValue({ error: { message: 'boom' } })
+        tableUpdate.mockReturnValue({ eq })
+
+        await expect(deleteNews({ id: 'n-1', photo_path: null })).rejects.toThrow('boom')
+    })
+})

--- a/src/admin/lib/adminApi/news.ts
+++ b/src/admin/lib/adminApi/news.ts
@@ -1,0 +1,98 @@
+import type { AdminNews, NewsInput } from '@/admin/lib/adminApi/types'
+import { NEWS_PHOTOS_BUCKET } from '@/admin/lib/adminApi/constants'
+import { db, runManyParsed, runOneParsed } from '@/admin/lib/adminApi/query'
+import { parseAdminNews } from '@/admin/lib/adminApi/parsers'
+
+const NEWS_COLUMNS = 'id, created_at, body, photo_path'
+
+/** Список новостей (не удалённых), новые сверху. */
+export async function listNews(): Promise<AdminNews[]> {
+    return runManyParsed(
+        'listNews',
+        db().from('map_news').select(NEWS_COLUMNS).is('deleted_at', null).order('created_at', { ascending: false }),
+        (raw) => parseAdminNews(raw),
+    )
+}
+
+export async function getNews(id: string): Promise<AdminNews> {
+    return runOneParsed('getNews', db().from('map_news').select(NEWS_COLUMNS).eq('id', id).single(), parseAdminNews)
+}
+
+export async function createNews(input: NewsInput): Promise<AdminNews> {
+    return runOneParsed('createNews', db().from('map_news').insert(input).select(NEWS_COLUMNS).single(), parseAdminNews)
+}
+
+export async function updateNews(id: string, input: Partial<NewsInput>): Promise<AdminNews> {
+    return runOneParsed(
+        'updateNews',
+        db().from('map_news').update(input).eq('id', id).select(NEWS_COLUMNS).single(),
+        parseAdminNews,
+    )
+}
+
+/**
+ * Мягко удаляет новость (deleted_at) и удаляет её фото из Storage.
+ * Строки telegram_outbound_messages остаются (история отправок); сами сообщения
+ * в Telegram при необходимости удаляются отдельно через deleteNewsAnnouncements.
+ */
+export async function deleteNews(news: Pick<AdminNews, 'id' | 'photo_path'>): Promise<void> {
+    if (news.photo_path) {
+        await db().storage.from(NEWS_PHOTOS_BUCKET).remove([news.photo_path])
+    }
+    const { error } = await db().from('map_news').update({ deleted_at: new Date().toISOString() }).eq('id', news.id)
+    if (error) {
+        console.error('deleteNews:', error)
+        throw new Error(error.message)
+    }
+}
+
+/**
+ * Загружает фотографию новости в Storage и сохраняет путь в `photo_path`.
+ * Старое фото (если было) удаляется. Возвращает обновлённую новость.
+ */
+export async function setNewsPhoto(newsId: string, file: File, previousPath: string | null): Promise<AdminNews> {
+    const ext = file.name.split('.').pop()?.toLowerCase() ?? 'jpg'
+    const safeExt = /^(jpe?g|png|webp)$/.test(ext) ? ext.replace('jpeg', 'jpg') : 'jpg'
+    const storagePath = `${newsId}/${crypto.randomUUID()}.${safeExt}`
+
+    const { error: uploadError } = await db()
+        .storage.from(NEWS_PHOTOS_BUCKET)
+        .upload(storagePath, file, { contentType: file.type, upsert: false })
+    if (uploadError) {
+        console.error('setNewsPhoto:storage', uploadError)
+        throw new Error(uploadError.message)
+    }
+
+    try {
+        const updated = await runOneParsed(
+            'setNewsPhoto',
+            db().from('map_news').update({ photo_path: storagePath }).eq('id', newsId).select(NEWS_COLUMNS).single(),
+            parseAdminNews,
+        )
+        if (previousPath && previousPath !== storagePath) {
+            await db().storage.from(NEWS_PHOTOS_BUCKET).remove([previousPath])
+        }
+        return updated
+    } catch (err) {
+        await db().storage.from(NEWS_PHOTOS_BUCKET).remove([storagePath])
+        throw err
+    }
+}
+
+/** Удаляет фотографию новости из Storage и обнуляет `photo_path`. */
+export async function deleteNewsPhoto(newsId: string, photoPath: string): Promise<AdminNews> {
+    const { error: storageError } = await db().storage.from(NEWS_PHOTOS_BUCKET).remove([photoPath])
+    if (storageError) {
+        console.warn('deleteNewsPhoto:storage', storageError)
+    }
+    return runOneParsed(
+        'deleteNewsPhoto',
+        db().from('map_news').update({ photo_path: null }).eq('id', newsId).select(NEWS_COLUMNS).single(),
+        parseAdminNews,
+    )
+}
+
+/** Публичный URL фотографии новости (для предпросмотра в админке). */
+export function newsPhotoUrl(photoPath: string): string {
+    return db().storage.from(NEWS_PHOTOS_BUCKET).getPublicUrl(photoPath).data.publicUrl
+}

--- a/src/admin/lib/adminApi/newsAnnouncements.test.ts
+++ b/src/admin/lib/adminApi/newsAnnouncements.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runManyParsed, invoke, fromTable, selectFn, eqFn, orderFn, db } = vi.hoisted(() => {
+    const invoke = vi.fn()
+    const orderFn = vi.fn()
+    const eqFn = vi.fn(() => ({ order: orderFn }))
+    const selectFn = vi.fn(() => ({ eq: eqFn }))
+    const fromTable = vi.fn(() => ({ select: selectFn }))
+    return {
+        runManyParsed: vi.fn(),
+        invoke,
+        fromTable,
+        selectFn,
+        eqFn,
+        orderFn,
+        db: vi.fn(() => ({ from: fromTable, functions: { invoke } })),
+    }
+})
+
+vi.mock('@/admin/lib/adminApi/query', () => ({
+    db,
+    runManyParsed,
+}))
+vi.mock('@/admin/lib/adminApi/parsers', () => ({
+    parseAdminNewsAnnouncement: (raw: unknown) => raw,
+    parseAnnounceResult: (raw: unknown) => raw,
+}))
+
+import {
+    announceNews,
+    deleteNewsAnnouncements,
+    editNewsAnnouncements,
+    listNewsAnnouncements,
+} from '@/admin/lib/adminApi/newsAnnouncements'
+
+const NEWS_ID = '11111111-2222-3333-4444-555555555555'
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    db.mockReturnValue({ from: fromTable, functions: { invoke } })
+    fromTable.mockReturnValue({ select: selectFn })
+    selectFn.mockReturnValue({ eq: eqFn })
+    eqFn.mockReturnValue({ order: orderFn })
+})
+
+describe('announceNews', () => {
+    it('вызывает /news-announce с news_id и destination_ids', async () => {
+        invoke.mockResolvedValue({ data: { sent: [], failed: [] }, error: null })
+
+        const result = await announceNews(NEWS_ID, ['d-1', 'd-2'])
+
+        expect(invoke).toHaveBeenCalledWith('telegram-location-bot/news-announce', {
+            body: { news_id: NEWS_ID, destination_ids: ['d-1', 'd-2'] },
+        })
+        expect(result).toEqual({ sent: [], failed: [] })
+    })
+
+    it('бросает ошибку Edge Function', async () => {
+        invoke.mockResolvedValue({ data: null, error: { message: 'boom' } })
+        await expect(announceNews(NEWS_ID, ['d-1'])).rejects.toThrow('boom')
+    })
+})
+
+describe('editNewsAnnouncements', () => {
+    it('вызывает /news-announce-edit и возвращает edited + failed', async () => {
+        invoke.mockResolvedValue({ data: { edited: 3, failed: [{ chat_id: -1, error: 'x' }] }, error: null })
+
+        const result = await editNewsAnnouncements(NEWS_ID)
+
+        expect(invoke).toHaveBeenCalledWith('telegram-location-bot/news-announce-edit', { body: { news_id: NEWS_ID } })
+        expect(result).toEqual({ edited: 3, failed: [{ chat_id: -1, error: 'x' }] })
+    })
+
+    it('failed по умолчанию пустой массив', async () => {
+        invoke.mockResolvedValue({ data: { edited: 0 }, error: null })
+        const result = await editNewsAnnouncements(NEWS_ID)
+        expect(result).toEqual({ edited: 0, failed: [] })
+    })
+})
+
+describe('deleteNewsAnnouncements', () => {
+    it('вызывает /news-announce-delete и возвращает deleted', async () => {
+        invoke.mockResolvedValue({ data: { deleted: 2 }, error: null })
+
+        const result = await deleteNewsAnnouncements(NEWS_ID)
+
+        expect(invoke).toHaveBeenCalledWith('telegram-location-bot/news-announce-delete', {
+            body: { news_id: NEWS_ID },
+        })
+        expect(result).toEqual({ deleted: 2 })
+    })
+})
+
+describe('listNewsAnnouncements', () => {
+    it('читает из telegram_outbound_messages по news_id, новые сверху', async () => {
+        runManyParsed.mockResolvedValue([])
+
+        await listNewsAnnouncements(NEWS_ID)
+
+        expect(fromTable).toHaveBeenCalledWith('telegram_outbound_messages')
+        expect(eqFn).toHaveBeenCalledWith('news_id', NEWS_ID)
+        expect(orderFn).toHaveBeenCalledWith('created_at', { ascending: false })
+    })
+})

--- a/src/admin/lib/adminApi/newsAnnouncements.ts
+++ b/src/admin/lib/adminApi/newsAnnouncements.ts
@@ -1,0 +1,53 @@
+import type { AdminNewsAnnouncement, AnnounceResult } from '@/admin/lib/adminApi/types'
+import { db, runManyParsed } from '@/admin/lib/adminApi/query'
+import { invokeAnnounce, numField } from '@/admin/lib/adminApi/announceClient'
+import { parseAdminNewsAnnouncement, parseAnnounceResult } from '@/admin/lib/adminApi/parsers'
+
+/**
+ * Отправляет новость в выбранные назначения (через Edge Function).
+ * destinationIds — суррогатные id строк telegram_chats (чат+тема), не chat_id.
+ */
+export async function announceNews(newsId: string, destinationIds: string[]): Promise<AnnounceResult> {
+    const data = await invokeAnnounce('news-announce', { news_id: newsId, destination_ids: destinationIds })
+    return parseAnnounceResult(data)
+}
+
+/**
+ * Меняет текст всех живых сообщений новости (берёт актуальное тело из map_news).
+ * Возвращает число изменённых сообщений и список ошибок по чатам.
+ */
+export async function editNewsAnnouncements(
+    newsId: string,
+): Promise<{ edited: number; failed: Array<{ chat_id: number; error: string }> }> {
+    const data = await invokeAnnounce('news-announce-edit', { news_id: newsId })
+    const rec = (data ?? {}) as { failed?: unknown }
+    return {
+        edited: numField(data, 'edited'),
+        failed: Array.isArray(rec.failed) ? (rec.failed as Array<{ chat_id: number; error: string }>) : [],
+    }
+}
+
+/**
+ * Удаляет сообщения новости из Telegram (строки помечаются deleted_at).
+ * Возвращает число удалённых сообщений.
+ */
+export async function deleteNewsAnnouncements(newsId: string): Promise<{ deleted: number }> {
+    const data = await invokeAnnounce('news-announce-delete', { news_id: newsId })
+    return { deleted: numField(data, 'deleted') }
+}
+
+const NEWS_ANNOUNCEMENT_COLUMNS =
+    'id, created_at, news_id, telegram_chat_id, message_thread_id, telegram_message_id, photo_path, sent_at, send_error, deleted_at'
+
+/** Отправленные сообщения новости (для индикации «уже отправлено» и истории). */
+export async function listNewsAnnouncements(newsId: string): Promise<AdminNewsAnnouncement[]> {
+    return runManyParsed(
+        'listNewsAnnouncements',
+        db()
+            .from('telegram_outbound_messages')
+            .select(NEWS_ANNOUNCEMENT_COLUMNS)
+            .eq('news_id', newsId)
+            .order('created_at', { ascending: false }),
+        (raw) => parseAdminNewsAnnouncement(raw),
+    )
+}

--- a/src/admin/lib/adminApi/parsers.test.ts
+++ b/src/admin/lib/adminApi/parsers.test.ts
@@ -6,6 +6,8 @@ import {
     parseAdminEventParticipant,
     parseAdminMapPoint,
     parseAdminMapRoute,
+    parseAdminNews,
+    parseAdminNewsAnnouncement,
     parseAdminTelegramChat,
     parseAnnounceResult,
 } from '@/admin/lib/adminApi/parsers'
@@ -378,6 +380,40 @@ describe('parseAdminEventDate', () => {
         ).toThrow()
         expect(() =>
             parseAdminTelegramChat({ chat_id: 1, title: 't', enabled: 'yes', sort_order: 0, created_at: 'y' }),
+        ).toThrow()
+    })
+
+    it('parseAdminNews принимает валидную строку и нормализует photo_path', () => {
+        const n = parseAdminNews({ id: 'n-1', created_at: 'x', body: 'Привет', photo_path: null })
+        expect(n).toEqual({ id: 'n-1', created_at: 'x', body: 'Привет', photo_path: null })
+        expect(parseAdminNews({ id: 'n-1', created_at: 'x', body: 'b', photo_path: 'p.jpg' }).photo_path).toBe('p.jpg')
+    })
+
+    it('parseAdminNews отклоняет отсутствующее body', () => {
+        expect(() => parseAdminNews({ id: 'n-1', created_at: 'x' })).toThrow()
+    })
+
+    it('parseAdminNewsAnnouncement нормализует nullable-поля', () => {
+        const a = parseAdminNewsAnnouncement({
+            id: 'a-1',
+            created_at: 'x',
+            news_id: 'n-1',
+            telegram_chat_id: -100,
+            message_thread_id: null,
+            telegram_message_id: 10,
+            photo_path: null,
+            sent_at: 'y',
+            send_error: null,
+            deleted_at: null,
+        })
+        expect(a.news_id).toBe('n-1')
+        expect(a.telegram_message_id).toBe(10)
+        expect(a.deleted_at).toBeNull()
+    })
+
+    it('parseAdminNewsAnnouncement отклоняет неверный telegram_chat_id', () => {
+        expect(() =>
+            parseAdminNewsAnnouncement({ id: 'a-1', created_at: 'x', news_id: 'n-1', telegram_chat_id: 'nope' }),
         ).toThrow()
     })
 })

--- a/src/admin/lib/adminApi/parsers.ts
+++ b/src/admin/lib/adminApi/parsers.ts
@@ -7,6 +7,8 @@ import type {
     AdminEventParticipant,
     AdminMapPoint,
     AdminMapRoute,
+    AdminNews,
+    AdminNewsAnnouncement,
     AdminSubmission,
     AdminTelegramChat,
     AnnounceResult,
@@ -329,6 +331,54 @@ export function parseAdminEventAnnouncement(raw: unknown): AdminEventAnnouncemen
         cancelled_at: asNullableString(raw.cancelled_at),
         deleted_at: asNullableString(raw.deleted_at),
         pinned_at: asNullableString(raw.pinned_at),
+    }
+}
+
+/** Валидирует строку `map_news`. */
+export function parseAdminNews(raw: unknown): AdminNews {
+    if (!isRecord(raw)) throw new Error('не объект')
+    const id = raw.id
+    const created_at = raw.created_at
+    const body = raw.body
+
+    if (typeof id !== 'string') throw new Error('id')
+    if (typeof created_at !== 'string') throw new Error('created_at')
+    if (typeof body !== 'string') throw new Error('body')
+
+    return {
+        id,
+        created_at,
+        body,
+        photo_path: asNullableString(raw.photo_path),
+    }
+}
+
+/** Валидирует строку `telegram_outbound_messages` с привязкой к новости (news_id). */
+export function parseAdminNewsAnnouncement(raw: unknown): AdminNewsAnnouncement {
+    if (!isRecord(raw)) throw new Error('не объект')
+    const id = raw.id
+    const created_at = raw.created_at
+    const news_id = raw.news_id
+    const telegram_chat_id = raw.telegram_chat_id
+
+    if (typeof id !== 'string') throw new Error('id')
+    if (typeof created_at !== 'string') throw new Error('created_at')
+    if (typeof news_id !== 'string') throw new Error('news_id')
+    if (typeof telegram_chat_id !== 'number' || !Number.isFinite(telegram_chat_id)) {
+        throw new Error('telegram_chat_id')
+    }
+
+    return {
+        id,
+        created_at,
+        news_id,
+        telegram_chat_id,
+        message_thread_id: asNullableNumber(raw.message_thread_id),
+        telegram_message_id: asNullableNumber(raw.telegram_message_id),
+        photo_path: asNullableString(raw.photo_path),
+        sent_at: asNullableString(raw.sent_at),
+        send_error: asNullableString(raw.send_error),
+        deleted_at: asNullableString(raw.deleted_at),
     }
 }
 

--- a/src/admin/lib/adminApi/types.ts
+++ b/src/admin/lib/adminApi/types.ts
@@ -177,3 +177,31 @@ export interface TelegramChatPatch {
     sort_order?: number
     message_thread_id?: number | null
 }
+
+export interface AdminNews {
+    id: string
+    created_at: string
+    /** Свободный текст новости (источник истины для отправки/правки). */
+    body: string
+    /** Путь к изображению новости в Storage (null — без картинки). */
+    photo_path: string | null
+}
+
+export interface NewsInput {
+    body: string
+}
+
+/** Отправленное в Telegram сообщение новости (строка telegram_outbound_messages с news_id). */
+export interface AdminNewsAnnouncement {
+    id: string
+    created_at: string
+    news_id: string
+    telegram_chat_id: number
+    /** Тема форумной группы, куда отправлено (null — обычный чат/General). */
+    message_thread_id: number | null
+    telegram_message_id: number | null
+    photo_path: string | null
+    sent_at: string | null
+    send_error: string | null
+    deleted_at: string | null
+}

--- a/src/admin/pages/NewsEditPage.tsx
+++ b/src/admin/pages/NewsEditPage.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+import { createNews, getNews, updateNews, type AdminNews } from '@/admin/lib/adminApi'
+import { NewsPhotoManager } from '@/admin/components/NewsPhotoManager'
+import { NewsAnnounceManager } from '@/admin/components/NewsAnnounceManager'
+
+interface NewsEditPageProps {
+    mode: 'create' | 'edit'
+}
+
+export function NewsEditPage({ mode }: NewsEditPageProps) {
+    const navigate = useNavigate()
+    const params = useParams<{ id?: string }>()
+    const newsId = mode === 'edit' && params.id ? params.id : null
+
+    const [news, setNews] = useState<AdminNews | null>(null)
+    const [body, setBody] = useState('')
+    const [error, setError] = useState<string | null>(null)
+    const [saving, setSaving] = useState(false)
+
+    useEffect(() => {
+        if (mode !== 'edit' || newsId === null) return
+        const state = { cancelled: false }
+        void (async () => {
+            try {
+                const loaded = await getNews(newsId)
+                if (!state.cancelled) {
+                    setNews(loaded)
+                    setBody(loaded.body)
+                }
+            } catch (err) {
+                if (!state.cancelled) setError(err instanceof Error ? err.message : String(err))
+            }
+        })()
+        return () => {
+            state.cancelled = true
+        }
+    }, [mode, newsId])
+
+    // Несохранённые изменения текста (для предупреждения в блоке рассылки).
+    const hasUnsavedChanges = mode === 'edit' && news !== null && body !== news.body
+
+    const handleSave = async () => {
+        if (body.trim().length === 0) {
+            setError('Введите текст новости.')
+            return
+        }
+        setSaving(true)
+        setError(null)
+        try {
+            if (mode === 'create') {
+                const created = await createNews({ body })
+                await navigate(`/admin/news/${created.id}`, { replace: true })
+            } else if (newsId !== null) {
+                const updated = await updateNews(newsId, { body })
+                setNews(updated)
+                setBody(updated.body)
+            }
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    return (
+        <section className="w-full max-w-none">
+            <header className="mb-4">
+                <h1 className="text-xl font-semibold">{mode === 'create' ? 'Новая новость' : 'Новость'}</h1>
+            </header>
+
+            {error && <div className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+
+            <div className="flex flex-col gap-6">
+                <div className="rounded-xl border border-neutral-200 bg-white p-4">
+                    <label className="block text-xs font-medium text-neutral-700">Текст новости</label>
+                    <textarea
+                        value={body}
+                        onChange={(e) => {
+                            setBody(e.target.value)
+                        }}
+                        rows={6}
+                        placeholder="Текст новости для отправки в чаты…"
+                        className="mt-1 w-full resize-y rounded-lg border border-neutral-300 bg-white px-3 py-2 text-sm"
+                    />
+                    <div className="mt-3 flex items-center gap-2">
+                        <button
+                            type="button"
+                            disabled={saving}
+                            onClick={() => {
+                                void handleSave()
+                            }}
+                            className="cursor-pointer rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:bg-blue-300"
+                        >
+                            {saving ? 'Сохранение…' : mode === 'create' ? 'Создать' : 'Сохранить'}
+                        </button>
+                        <button
+                            type="button"
+                            disabled={saving}
+                            onClick={() => {
+                                void navigate('/admin/news')
+                            }}
+                            className="cursor-pointer rounded-lg border border-neutral-300 px-3 py-2 text-sm font-medium hover:bg-neutral-100 disabled:opacity-50"
+                        >
+                            К списку
+                        </button>
+                    </div>
+                </div>
+
+                {mode === 'edit' && newsId !== null && news && (
+                    <>
+                        <NewsPhotoManager
+                            newsId={newsId}
+                            photoPath={news.photo_path}
+                            onChange={(nextPath) => {
+                                setNews((prev) => (prev ? { ...prev, photo_path: nextPath } : prev))
+                            }}
+                        />
+                        <NewsAnnounceManager newsId={newsId} body={news.body} hasUnsavedChanges={hasUnsavedChanges} />
+                    </>
+                )}
+            </div>
+        </section>
+    )
+}

--- a/src/admin/pages/NewsPage.tsx
+++ b/src/admin/pages/NewsPage.tsx
@@ -1,0 +1,133 @@
+import { useCallback, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { deleteNews, listNews, type AdminNews } from '@/admin/lib/adminApi'
+import { useAdminListLoader } from '@/admin/hooks/useAdminListLoader'
+import { ConfirmDialog } from '@/admin/components/ConfirmDialog'
+import { formatAdminDate } from '@/admin/utils/formatAdminDate'
+import { newsTitlePreview } from '@/utils/newsAnnounce'
+
+export function NewsPage() {
+    const navigate = useNavigate()
+    const [confirm, setConfirm] = useState<AdminNews | null>(null)
+    const [deleting, setDeleting] = useState(false)
+
+    const load = useCallback(() => listNews(), [])
+    const { items, loading, error, reload } = useAdminListLoader(load)
+
+    const handleDelete = async () => {
+        if (!confirm) return
+        setDeleting(true)
+        try {
+            await deleteNews({ id: confirm.id, photo_path: confirm.photo_path })
+            await reload()
+        } catch (err) {
+            window.alert(err instanceof Error ? err.message : String(err))
+        } finally {
+            setDeleting(false)
+            setConfirm(null)
+        }
+    }
+
+    return (
+        <section>
+            <header className="mb-4 flex items-center justify-between gap-4">
+                <div>
+                    <h1 className="text-xl font-semibold">Новости проекта</h1>
+                    <p className="mt-1 text-sm text-neutral-600">
+                        Сообщения для рассылки в Telegram-чаты. Можно отправить в выбранные чаты, обновить текст во всех
+                        отправленных или удалить их.
+                    </p>
+                </div>
+                <div className="flex items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={() => {
+                            void reload()
+                        }}
+                        className="cursor-pointer rounded-lg border border-neutral-300 px-3 py-2 text-sm font-medium hover:bg-neutral-100"
+                    >
+                        Обновить
+                    </button>
+                    <Link
+                        to="new"
+                        className="cursor-pointer rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+                    >
+                        Создать
+                    </Link>
+                </div>
+            </header>
+
+            {error && <div className="mb-4 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+
+            <div className="overflow-hidden rounded-xl border border-neutral-200 bg-white">
+                <table className="w-full text-sm">
+                    <thead className="border-b border-neutral-200 bg-neutral-50 text-left text-xs uppercase tracking-wide text-neutral-500">
+                        <tr>
+                            <th className="px-3 py-2 font-medium">Новость</th>
+                            <th className="px-3 py-2 font-medium">Создано</th>
+                            <th className="px-3 py-2 font-medium"></th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y divide-neutral-200">
+                        {loading && (
+                            <tr>
+                                <td colSpan={3} className="px-3 py-6 text-center text-neutral-500">
+                                    Загрузка…
+                                </td>
+                            </tr>
+                        )}
+                        {!loading && items.length === 0 && (
+                            <tr>
+                                <td colSpan={3} className="px-3 py-6 text-center text-neutral-500">
+                                    Новостей пока нет.
+                                </td>
+                            </tr>
+                        )}
+                        {items.map((news) => (
+                            <tr
+                                key={news.id}
+                                onClick={() => {
+                                    void navigate(`/admin/news/${news.id}`)
+                                }}
+                                className="cursor-pointer hover:bg-neutral-50"
+                            >
+                                <td className="px-3 py-2 font-medium">
+                                    {newsTitlePreview(news.body) || (
+                                        <span className="text-neutral-400">(без текста)</span>
+                                    )}
+                                </td>
+                                <td className="px-3 py-2 text-neutral-600">{formatAdminDate(news.created_at)}</td>
+                                <td className="px-3 py-2 text-right">
+                                    <button
+                                        type="button"
+                                        onClick={(e) => {
+                                            e.stopPropagation()
+                                            setConfirm(news)
+                                        }}
+                                        className="cursor-pointer rounded-lg border border-red-200 px-2 py-1 text-xs text-red-700 hover:bg-red-50"
+                                    >
+                                        Удалить
+                                    </button>
+                                </td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            <ConfirmDialog
+                open={confirm !== null}
+                title="Удалить новость?"
+                description="Новость скроется из списка, фото удалится. Отправленные сообщения в Telegram останутся — удалите их отдельно на странице новости перед удалением."
+                confirmLabel="Удалить"
+                danger
+                onCancel={() => {
+                    if (!deleting) setConfirm(null)
+                }}
+                onConfirm={() => {
+                    void handleDelete()
+                }}
+            />
+        </section>
+    )
+}

--- a/src/utils/eventAnnounce.ts
+++ b/src/utils/eventAnnounce.ts
@@ -27,7 +27,7 @@ export function buildAnnouncementPreviewHeader(
 }
 
 /** Ключ назначения рассылки: чат + тема. NULL-тема нормализуется отдельно от любого id темы. */
-function destinationKey(chatId: number, threadId: number | null): string {
+export function destinationKey(chatId: number, threadId: number | null): string {
     return `${String(chatId)}:${threadId === null ? '' : String(threadId)}`
 }
 

--- a/src/utils/newsAnnounce.test.ts
+++ b/src/utils/newsAnnounce.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import { newsTitlePreview, pendingNewsChats } from '@/utils/newsAnnounce'
+import type { AdminNewsAnnouncement, AdminTelegramChat } from '@/admin/lib/adminApi/types'
+
+const NEWS_ID = '11111111-2222-3333-4444-555555555555'
+
+function makeChat(over: Partial<AdminTelegramChat> = {}): AdminTelegramChat {
+    return {
+        id: 'd-1',
+        chat_id: -100,
+        title: 'Чат',
+        enabled: true,
+        sort_order: 0,
+        created_at: '2026-01-01T00:00:00Z',
+        message_thread_id: null,
+        ...over,
+    }
+}
+
+function makeAnn(over: Partial<AdminNewsAnnouncement> = {}): AdminNewsAnnouncement {
+    return {
+        id: 'a-1',
+        created_at: '2026-01-01T00:00:00Z',
+        news_id: NEWS_ID,
+        telegram_chat_id: -100,
+        message_thread_id: null,
+        telegram_message_id: 10,
+        photo_path: null,
+        sent_at: '2026-01-01T00:00:00Z',
+        send_error: null,
+        deleted_at: null,
+        ...over,
+    }
+}
+
+describe('newsTitlePreview', () => {
+    it('берёт первую непустую строку', () => {
+        expect(newsTitlePreview('\n  \nПривет мир\nвторая строка')).toBe('Привет мир')
+    })
+
+    it('обрезает длинную строку с многоточием', () => {
+        const long = 'a'.repeat(100)
+        const result = newsTitlePreview(long, 80)
+        expect(result.endsWith('…')).toBe(true)
+        expect(result.length).toBe(81)
+    })
+
+    it('пустое тело → пустая строка', () => {
+        expect(newsTitlePreview('   \n  ')).toBe('')
+    })
+})
+
+describe('pendingNewsChats', () => {
+    it('исключает чаты с живым сообщением (chat_id + thread)', () => {
+        const chats = [makeChat({ id: 'd-1', chat_id: -100 }), makeChat({ id: 'd-2', chat_id: -200 })]
+        const anns = [makeAnn({ telegram_chat_id: -100 })]
+        expect(pendingNewsChats(chats, anns).map((c) => c.id)).toEqual(['d-2'])
+    })
+
+    it('удалённое/ошибочное сообщение не считается отправленным — чат снова доступен', () => {
+        const chats = [makeChat({ id: 'd-1', chat_id: -100 })]
+        const deleted = [makeAnn({ telegram_chat_id: -100, deleted_at: '2026-02-01T00:00:00Z' })]
+        const failed = [makeAnn({ telegram_chat_id: -100, telegram_message_id: null, send_error: 'boom' })]
+        expect(pendingNewsChats(chats, deleted).map((c) => c.id)).toEqual(['d-1'])
+        expect(pendingNewsChats(chats, failed).map((c) => c.id)).toEqual(['d-1'])
+    })
+
+    it('разные темы одного чата различаются', () => {
+        const chats = [
+            makeChat({ id: 'd-1', chat_id: -100, message_thread_id: null }),
+            makeChat({ id: 'd-2', chat_id: -100, message_thread_id: 5 }),
+        ]
+        const anns = [makeAnn({ telegram_chat_id: -100, message_thread_id: 5 })]
+        expect(pendingNewsChats(chats, anns).map((c) => c.id)).toEqual(['d-1'])
+    })
+})

--- a/src/utils/newsAnnounce.ts
+++ b/src/utils/newsAnnounce.ts
@@ -1,0 +1,35 @@
+import type { AdminNewsAnnouncement, AdminTelegramChat } from '@/admin/lib/adminApi/types'
+import { destinationKey } from '@/utils/eventAnnounce'
+
+/** Живое сообщение новости: успешно отправлено и не удалено. */
+function isLiveNewsAnnouncement(a: AdminNewsAnnouncement): boolean {
+    return a.telegram_message_id !== null && a.send_error === null && a.deleted_at === null
+}
+
+/**
+ * Назначения (чат+тема), в которые новость ещё НЕ отправлена — для до-отправки из режима правки.
+ * «Отправлено» = есть живое сообщение с тем же (chat_id, message_thread_id). Удалённые/ошибочные
+ * не считаются отправленными, чтобы такой чат снова попал в список доступных.
+ */
+export function pendingNewsChats(
+    chats: AdminTelegramChat[],
+    announcements: AdminNewsAnnouncement[],
+): AdminTelegramChat[] {
+    const live = new Set(
+        announcements
+            .filter(isLiveNewsAnnouncement)
+            .map((a) => destinationKey(a.telegram_chat_id, a.message_thread_id)),
+    )
+    return chats.filter((c) => !live.has(destinationKey(c.chat_id, c.message_thread_id)))
+}
+
+/** Первая непустая строка новости — короткий заголовок для списков. */
+export function newsTitlePreview(body: string, maxLength = 80): string {
+    const firstLine =
+        body
+            .split('\n')
+            .find((line) => line.trim().length > 0)
+            ?.trim() ?? ''
+    if (firstLine.length <= maxLength) return firstLine
+    return `${firstLine.slice(0, maxLength).trimEnd()}…`
+}

--- a/supabase/functions/telegram-location-bot/_handlers.test.ts
+++ b/supabase/functions/telegram-location-bot/_handlers.test.ts
@@ -9,6 +9,9 @@ import {
     handleDeleteAnnouncements,
     handleEditAnnouncements,
     handlePinAnnouncement,
+    handleAnnounceNews,
+    handleEditNews,
+    handleDeleteNews,
     isAdminRequest,
 } from './_handlers.ts'
 import type { TelegramCallbackQuery } from './_pure.ts'
@@ -316,7 +319,7 @@ Deno.test('handleCallbackQuery: новый участник → insert + тос�
             return { count: 1, error: null }
         },
         // дата разослана в два чата — обновить нужно оба сообщения
-        map_event_announcements: () => ({
+        telegram_outbound_messages: () => ({
             data: [
                 { telegram_chat_id: -200, telegram_message_id: 42 },
                 { telegram_chat_id: -300, telegram_message_id: 99 },
@@ -357,7 +360,7 @@ Deno.test(
                 if (op === 'insert') return { data: null, error: null }
                 return { count: 1, error: null }
             },
-            map_event_announcements: (op) =>
+            telegram_outbound_messages: (op) =>
                 op === 'select'
                     ? { data: [{ id: 'a1', telegram_chat_id: -200, telegram_message_id: 42 }], error: null }
                     : { error: null },
@@ -372,7 +375,7 @@ Deno.test(
         try {
             await handleCallbackQuery(client, makeCb(`rsvp:${VALID_UUID}`), 'TOKEN', 'https://map.euc.kz')
             // строка-«призрак» помечена deleted_at
-            const updates = opsLog.filter((o) => o.table === 'map_event_announcements' && o.op === 'update')
+            const updates = opsLog.filter((o) => o.table === 'telegram_outbound_messages' && o.op === 'update')
             assertEquals(updates.length, 1)
             assertEquals(Object.prototype.hasOwnProperty.call(updates[0].payload, 'deleted_at'), true)
         } finally {
@@ -430,7 +433,7 @@ function announceHandlers(): Record<string, TableHandler> {
         telegram_chats: () => ({ data: [{ chat_id: -200 }], error: null }),
         map_event_participants: () => ({ count: 0, error: null }),
         // insert ... .select('id').single() → строка с id (нужно для последующего pin)
-        map_event_announcements: (op) =>
+        telegram_outbound_messages: (op) =>
             op === 'insert' ? { data: { id: 'new-ann' }, error: null } : { data: null, error: null },
     }
 }
@@ -509,7 +512,7 @@ Deno.test('handleAnnounceEventDate: сохраняет сырое body_text и p
             'TOKEN',
             'https://map.euc.kz',
         )
-        const insert = opsLog.find((o) => o.table === 'map_event_announcements' && o.op === 'insert')!
+        const insert = opsLog.find((o) => o.table === 'telegram_outbound_messages' && o.op === 'insert')!
         const payload = insert.payload as { body_text: string; photo_path: string | null }
         assertEquals(payload.body_text, 'Сбор у фонтана')
         // в announceHandlers photo_path = null
@@ -616,7 +619,7 @@ function editDeleteHandlers(): Record<string, TableHandler> {
             error: null,
         }),
         map_event_participants: () => ({ count: 0, error: null }),
-        map_event_announcements: (op) =>
+        telegram_outbound_messages: (op) =>
             op === 'select'
                 ? {
                       data: [
@@ -661,7 +664,7 @@ Deno.test('handleEditAnnouncements: правит текст во всех соо
         // новый текст содержит свободное тело и не равен старому снимку
         assertEquals((edits[0].body as { text: string }).text.includes('новый текст'), true)
         // снимок текста обновлён в БД по каждой строке: message_text (со шапкой) + сырое body_text
-        const updates = opsLog.filter((o) => o.table === 'map_event_announcements' && o.op === 'update')
+        const updates = opsLog.filter((o) => o.table === 'telegram_outbound_messages' && o.op === 'update')
         assertEquals(updates.length, 2)
         const payload = updates[0].payload as { message_text: string; body_text: string }
         assertEquals(payload.body_text, 'новый текст')
@@ -677,7 +680,7 @@ Deno.test(
         // Строки с photo_path → редактируются как подпись (детерминированно по типу, без пробного вызова).
         const handlers: Record<string, TableHandler> = {
             ...editDeleteHandlers(),
-            map_event_announcements: (op) =>
+            telegram_outbound_messages: (op) =>
                 op === 'select'
                     ? {
                           data: [
@@ -740,7 +743,7 @@ Deno.test('handleEditAnnouncements: сообщение удалено из ча�
         assertEquals(json.edited, 0)
         assertEquals(json.failed.length, 2)
         // обе строки помечены deleted_at (самоочищение из живых)
-        const updates = opsLog.filter((o) => o.table === 'map_event_announcements' && o.op === 'update')
+        const updates = opsLog.filter((o) => o.table === 'telegram_outbound_messages' && o.op === 'update')
         assertEquals(updates.length, 2)
         assertEquals(Object.prototype.hasOwnProperty.call(updates[0].payload, 'deleted_at'), true)
     } finally {
@@ -784,7 +787,7 @@ Deno.test('handleDeleteAnnouncements: deleteMessage во всех чатах + �
         assertEquals(json.deleted, 2)
         assertEquals(calls.filter((c) => methodOf(c.url) === 'deleteMessage').length, 2)
         // обе строки помечены deleted_at
-        const updates = opsLog.filter((o) => o.table === 'map_event_announcements' && o.op === 'update')
+        const updates = opsLog.filter((o) => o.table === 'telegram_outbound_messages' && o.op === 'update')
         assertEquals(updates.length, 2)
         assertEquals(Object.prototype.hasOwnProperty.call(updates[0].payload, 'deleted_at'), true)
     } finally {
@@ -805,7 +808,7 @@ Deno.test('handleDeleteAnnouncements: deleteMessage упал → строка в
         )
         const json = (await res.json()) as { deleted: number }
         assertEquals(json.deleted, 2)
-        assertEquals(opsLog.filter((o) => o.table === 'map_event_announcements' && o.op === 'update').length, 2)
+        assertEquals(opsLog.filter((o) => o.table === 'telegram_outbound_messages' && o.op === 'update').length, 2)
     } finally {
         restore()
     }
@@ -829,7 +832,7 @@ const PIN_ANN_ID = '99999999-2222-3333-4444-555555555555'
 function pinHandlers(): Record<string, TableHandler> {
     return {
         map_admin_users: () => ({ data: { user_id: 'admin-1' }, error: null }),
-        map_event_announcements: (op) =>
+        telegram_outbound_messages: (op) =>
             op === 'select'
                 ? { data: { id: PIN_ANN_ID, telegram_chat_id: -200, telegram_message_id: 42 }, error: null }
                 : { error: null },
@@ -852,7 +855,7 @@ Deno.test('handlePinAnnouncement: pin=true → pinChatMessage + update pinned_at
             calls.some((c) => methodOf(c.url) === 'pinChatMessage'),
             true,
         )
-        const upd = opsLog.find((o) => o.table === 'map_event_announcements' && o.op === 'update')!
+        const upd = opsLog.find((o) => o.table === 'telegram_outbound_messages' && o.op === 'update')!
         assertEquals(typeof (upd.payload as { pinned_at: unknown }).pinned_at, 'string')
     } finally {
         restore()
@@ -874,7 +877,7 @@ Deno.test('handlePinAnnouncement: pin=false → unpinChatMessage + pinned_at=nul
             calls.some((c) => methodOf(c.url) === 'unpinChatMessage'),
             true,
         )
-        const upd = opsLog.find((o) => o.table === 'map_event_announcements' && o.op === 'update')!
+        const upd = opsLog.find((o) => o.table === 'telegram_outbound_messages' && o.op === 'update')!
         assertEquals((upd.payload as { pinned_at: unknown }).pinned_at, null)
     } finally {
         restore()
@@ -894,7 +897,7 @@ Deno.test('handlePinAnnouncement: Telegram отказал → 502, pinned_at н�
         )
         assertEquals(res.status, 502)
         assertEquals(
-            opsLog.some((o) => o.table === 'map_event_announcements' && o.op === 'update'),
+            opsLog.some((o) => o.table === 'telegram_outbound_messages' && o.op === 'update'),
             false,
         )
     } finally {
@@ -906,7 +909,7 @@ Deno.test('handlePinAnnouncement: строки нет (удалена/чужая
     const { client } = makeFakeSupabase(
         {
             map_admin_users: () => ({ data: { user_id: 'admin-1' }, error: null }),
-            map_event_announcements: () => ({ data: null, error: null }),
+            telegram_outbound_messages: () => ({ data: null, error: null }),
         },
         { adminUserId: 'admin-1' },
     )
@@ -996,4 +999,153 @@ Deno.test('handleAvatarBackfill: безопасные URL пропускаютс
     assertEquals(json.processed, 2)
     assertEquals(json.skipped_safe, 2)
     assertEquals(json.updated, 0)
+})
+
+// ───────────────────────────── Новости проекта ─────────────────────────────
+
+/** Запрос на /news-* от админа с заданным телом. */
+function newsReq(body: unknown): Request {
+    return new Request('https://x/news-announce', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer jwt', 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    })
+}
+
+Deno.test('handleAnnounceNews: шлёт sendMessage в выбранные чаты и пишет строку с news_id', async () => {
+    const { client, opsLog } = makeFakeSupabase(
+        {
+            map_admin_users: () => ({ data: { user_id: 'admin-1' }, error: null }),
+            map_news: () => ({ data: { body: 'Привет', photo_path: null, deleted_at: null }, error: null }),
+            telegram_chats: () => ({ data: [{ chat_id: -200, message_thread_id: null }], error: null }),
+            telegram_outbound_messages: () => ({ data: null, error: null }),
+        },
+        { adminUserId: 'admin-1' },
+    )
+    const { calls, restore } = installFetchMock(() => tgOk({ message_id: 77 }))
+    try {
+        const res = await handleAnnounceNews(client, newsReq({ news_id: VALID_UUID, destination_ids: ['d1'] }), 'TOKEN')
+        const json = (await res.json()) as { sent: Array<{ chat_id: number; message_id: number }>; failed: unknown[] }
+        assertEquals(json.sent, [{ chat_id: -200, message_id: 77 }])
+        assertEquals(json.failed.length, 0)
+        assertEquals(methodOf(calls[0].url), 'sendMessage')
+        const insert = opsLog.find((o) => o.table === 'telegram_outbound_messages' && o.op === 'insert')!
+        assertEquals((insert.payload as { news_id: string }).news_id, VALID_UUID)
+        assertEquals((insert.payload as { telegram_message_id: number }).telegram_message_id, 77)
+    } finally {
+        restore()
+    }
+})
+
+Deno.test('handleAnnounceNews: фото у новости → sendPhoto с caption', async () => {
+    const { client } = makeFakeSupabase(
+        {
+            map_admin_users: () => ({ data: { user_id: 'admin-1' }, error: null }),
+            map_news: () => ({ data: { body: 'Текст', photo_path: 'n/1.jpg', deleted_at: null }, error: null }),
+            telegram_chats: () => ({ data: [{ chat_id: -200, message_thread_id: null }], error: null }),
+            telegram_outbound_messages: () => ({ data: null, error: null }),
+        },
+        { adminUserId: 'admin-1' },
+    )
+    const { calls, restore } = installFetchMock(() => tgOk({ message_id: 5 }))
+    try {
+        await handleAnnounceNews(client, newsReq({ news_id: VALID_UUID, destination_ids: ['d1'] }), 'TOKEN')
+        assertEquals(methodOf(calls[0].url), 'sendPhoto')
+        assertEquals((calls[0].body as { caption: string }).caption, 'Текст')
+    } finally {
+        restore()
+    }
+})
+
+Deno.test('handleAnnounceNews: пустое тело → 400 empty_body', async () => {
+    const { client } = makeFakeSupabase(
+        {
+            map_admin_users: () => ({ data: { user_id: 'admin-1' }, error: null }),
+            map_news: () => ({ data: { body: '   ', photo_path: null, deleted_at: null }, error: null }),
+        },
+        { adminUserId: 'admin-1' },
+    )
+    const res = await handleAnnounceNews(client, newsReq({ news_id: VALID_UUID, destination_ids: ['d1'] }), 'TOKEN')
+    assertEquals(res.status, 400)
+    assertEquals(((await res.json()) as { error: string }).error, 'empty_body')
+})
+
+Deno.test('handleAnnounceNews: удалённая новость → 404 news_not_found', async () => {
+    const { client } = makeFakeSupabase(
+        {
+            map_admin_users: () => ({ data: { user_id: 'admin-1' }, error: null }),
+            map_news: () => ({
+                data: { body: 'x', photo_path: null, deleted_at: '2026-01-01T00:00:00Z' },
+                error: null,
+            }),
+        },
+        { adminUserId: 'admin-1' },
+    )
+    const res = await handleAnnounceNews(client, newsReq({ news_id: VALID_UUID, destination_ids: ['d1'] }), 'TOKEN')
+    assertEquals(res.status, 404)
+})
+
+Deno.test('handleEditNews: editMessageText во всех живых + обновление body_text', async () => {
+    const { client, opsLog } = makeFakeSupabase(
+        {
+            map_admin_users: () => ({ data: { user_id: 'admin-1' }, error: null }),
+            map_news: () => ({ data: { body: 'Новый текст', photo_path: null, deleted_at: null }, error: null }),
+            telegram_outbound_messages: (op) =>
+                op === 'select'
+                    ? {
+                          data: [
+                              { id: 'a1', telegram_chat_id: -200, telegram_message_id: 11, photo_path: null },
+                              { id: 'a2', telegram_chat_id: -300, telegram_message_id: 22, photo_path: null },
+                          ],
+                          error: null,
+                      }
+                    : { error: null },
+        },
+        { adminUserId: 'admin-1' },
+    )
+    const { calls, restore } = installFetchMock(() => tgOk())
+    try {
+        const res = await handleEditNews(client, newsReq({ news_id: VALID_UUID }), 'TOKEN')
+        const json = (await res.json()) as { edited: number; failed: unknown[] }
+        assertEquals(json.edited, 2)
+        assertEquals(json.failed.length, 0)
+        assertEquals(calls.filter((c) => methodOf(c.url) === 'editMessageText').length, 2)
+        const updates = opsLog.filter((o) => o.table === 'telegram_outbound_messages' && o.op === 'update')
+        assertEquals(updates.length, 2)
+        assertEquals((updates[0].payload as { body_text: string }).body_text, 'Новый текст')
+    } finally {
+        restore()
+    }
+})
+
+Deno.test('handleDeleteNews: deleteMessage + пометка deleted_at для каждого живого', async () => {
+    const { client, opsLog } = makeFakeSupabase(
+        {
+            map_admin_users: () => ({ data: { user_id: 'admin-1' }, error: null }),
+            telegram_outbound_messages: (op) =>
+                op === 'select'
+                    ? {
+                          data: [{ id: 'a1', telegram_chat_id: -200, telegram_message_id: 11, photo_path: null }],
+                          error: null,
+                      }
+                    : { error: null },
+        },
+        { adminUserId: 'admin-1' },
+    )
+    const { calls, restore } = installFetchMock(() => tgOk())
+    try {
+        const res = await handleDeleteNews(client, newsReq({ news_id: VALID_UUID }), 'TOKEN')
+        assertEquals(((await res.json()) as { deleted: number }).deleted, 1)
+        assertEquals(calls.filter((c) => methodOf(c.url) === 'deleteMessage').length, 1)
+        const updates = opsLog.filter((o) => o.table === 'telegram_outbound_messages' && o.op === 'update')
+        assertEquals(Object.prototype.hasOwnProperty.call(updates[0].payload, 'deleted_at'), true)
+    } finally {
+        restore()
+    }
+})
+
+Deno.test('handleAnnounceNews: не админ → 401', async () => {
+    const { client } = makeFakeSupabase({})
+    const res = await handleAnnounceNews(client, newsReq({ news_id: VALID_UUID, destination_ids: ['d1'] }), 'TOKEN')
+    assertEquals(res.status, 401)
 })

--- a/supabase/functions/telegram-location-bot/_handlers.ts
+++ b/supabase/functions/telegram-location-bot/_handlers.ts
@@ -12,6 +12,7 @@ import {
     TELEGRAM_AVATARS_BUCKET,
     UUID_RE,
     buildAnnouncementText,
+    buildNewsText,
     buildRsvpKeyboard,
     escapeHtml,
     isAvatarUrlSafe,
@@ -349,15 +350,20 @@ type LiveAnnouncement = {
 }
 
 /**
- * Живые анонсы даты: отправленные (telegram_message_id), не отменённые и не удалённые.
- * Единый источник для обновления счётчика (RSVP), отмены, правки текста и удаления.
+ * Живые исходящие сообщения по родителю (event_date_id или news_id): отправленные
+ * (telegram_message_id), не отменённые и не удалённые. Единый источник для обновления
+ * счётчика (RSVP), отмены, правки текста и удаления.
  * photo_path определяет тип сообщения (фото → caption, иначе → text) при редактировании.
  */
-async function listLiveAnnouncements(supabase: SupabaseClient, eventDateId: string): Promise<LiveAnnouncement[]> {
+async function listLiveAnnouncements(
+    supabase: SupabaseClient,
+    parentColumn: 'event_date_id' | 'news_id',
+    parentId: string,
+): Promise<LiveAnnouncement[]> {
     const { data } = await supabase
-        .from('map_event_announcements')
+        .from('telegram_outbound_messages')
         .select('id, telegram_chat_id, telegram_message_id, message_text, photo_path')
-        .eq('event_date_id', eventDateId)
+        .eq(parentColumn, parentId)
         .not('telegram_message_id', 'is', null)
         .is('cancelled_at', null)
         .is('deleted_at', null)
@@ -375,8 +381,8 @@ function isMessageGoneError(description: string | undefined): boolean {
 }
 
 /** Помечает строку анонса как удалённую — самоочищение «призраков» из listLiveAnnouncements. */
-async function markAnnouncementDeleted(supabase: SupabaseClient, id: string): Promise<void> {
-    await supabase.from('map_event_announcements').update({ deleted_at: new Date().toISOString() }).eq('id', id)
+async function markOutboundDeleted(supabase: SupabaseClient, id: string): Promise<void> {
+    await supabase.from('telegram_outbound_messages').update({ deleted_at: new Date().toISOString() }).eq('id', id)
 }
 
 /**
@@ -412,7 +418,7 @@ async function setAnnouncementPinned(
         return { ok: false, pinned: !pin, description: result.description }
     }
     await supabase
-        .from('map_event_announcements')
+        .from('telegram_outbound_messages')
         .update({ pinned_at: pin ? new Date().toISOString() : null })
         .eq('id', row.id)
     return { ok: true, pinned: pin }
@@ -424,7 +430,7 @@ async function setAnnouncementPinned(
  * Единый примитив для правки и отмены — без пробного вызова с фолбэком.
  */
 async function editAnnouncementContent(
-    row: LiveAnnouncement,
+    row: Pick<LiveAnnouncement, 'telegram_chat_id' | 'telegram_message_id' | 'photo_path'>,
     text: string,
     botToken: string,
     replyMarkup?: { inline_keyboard: unknown[] },
@@ -452,7 +458,7 @@ async function refreshAnnouncementKeyboards(
     mapBaseUrl: string,
     botToken: string,
 ): Promise<void> {
-    const rows = await listLiveAnnouncements(supabase, eventDateId)
+    const rows = await listLiveAnnouncements(supabase, 'event_date_id', eventDateId)
     const keyboard = buildRsvpKeyboard(eventDateId, count, mapBaseUrl, eventId)
     for (const row of rows) {
         const editResult = await callTelegramApi(
@@ -471,7 +477,7 @@ async function refreshAnnouncementKeyboards(
                 description: editResult.description,
             })
             // Сообщение удалено из чата → выводим анонс из живых, чтобы не дёргать его впредь.
-            if (isMessageGoneError(editResult.description)) await markAnnouncementDeleted(supabase, row.id)
+            if (isMessageGoneError(editResult.description)) await markOutboundDeleted(supabase, row.id)
         }
     }
 }
@@ -637,7 +643,7 @@ export async function handleAnnounceEventDate(
 
         if (apiResult.ok && messageId !== null) {
             const { data: inserted } = await supabase
-                .from('map_event_announcements')
+                .from('telegram_outbound_messages')
                 .insert({
                     event_date_id: eventDateId,
                     telegram_chat_id: chatId,
@@ -668,7 +674,7 @@ export async function handleAnnounceEventDate(
             )
         } else {
             const errText = apiResult.description ?? 'send_failed'
-            await supabase.from('map_event_announcements').insert({
+            await supabase.from('telegram_outbound_messages').insert({
                 event_date_id: eventDateId,
                 telegram_chat_id: chatId,
                 message_thread_id: threadId,
@@ -697,7 +703,7 @@ export async function handleCancelAnnouncements(
     if (guard instanceof Response) return guard
     const { eventDateId, botToken: token } = guard
 
-    const rows = await listLiveAnnouncements(supabase, eventDateId)
+    const rows = await listLiveAnnouncements(supabase, 'event_date_id', eventDateId)
 
     let cancelled = 0
     for (const r of rows) {
@@ -708,7 +714,10 @@ export async function handleCancelAnnouncements(
             { chat_id: r.telegram_chat_id, message_id: r.telegram_message_id, reply_markup: { inline_keyboard: [] } },
             token,
         )
-        await supabase.from('map_event_announcements').update({ cancelled_at: new Date().toISOString() }).eq('id', r.id)
+        await supabase
+            .from('telegram_outbound_messages')
+            .update({ cancelled_at: new Date().toISOString() })
+            .eq('id', r.id)
         cancelled += 1
     }
 
@@ -737,7 +746,7 @@ export async function handleEditAnnouncements(
     const text = buildAnnouncementText(ctx.event, ctx.startsAt, bodyText)
     const count = await countEventParticipants(supabase, eventDateId)
     const keyboard = buildRsvpKeyboard(eventDateId, count, mapBaseUrl, ctx.eventId)
-    const rows = await listLiveAnnouncements(supabase, eventDateId)
+    const rows = await listLiveAnnouncements(supabase, 'event_date_id', eventDateId)
 
     let edited = 0
     const failed: Array<{ chat_id: number; error: string }> = []
@@ -746,14 +755,14 @@ export async function handleEditAnnouncements(
 
         if (editResult.ok) {
             await supabase
-                .from('map_event_announcements')
+                .from('telegram_outbound_messages')
                 .update({ message_text: text, body_text: bodyText })
                 .eq('id', r.id)
             edited += 1
         } else {
             failed.push({ chat_id: r.telegram_chat_id, error: editResult.description ?? 'edit_failed' })
             // Сообщение удалено из чата → выводим из живых (иначе «призрак» вечно в failed).
-            if (isMessageGoneError(editResult.description)) await markAnnouncementDeleted(supabase, r.id)
+            if (isMessageGoneError(editResult.description)) await markOutboundDeleted(supabase, r.id)
         }
     }
 
@@ -773,7 +782,7 @@ export async function handleDeleteAnnouncements(
     if (guard instanceof Response) return guard
     const { eventDateId, botToken: token } = guard
 
-    const rows = await listLiveAnnouncements(supabase, eventDateId)
+    const rows = await listLiveAnnouncements(supabase, 'event_date_id', eventDateId)
 
     let deleted = 0
     for (const r of rows) {
@@ -790,7 +799,10 @@ export async function handleDeleteAnnouncements(
                 description: delResult.description,
             })
         }
-        await supabase.from('map_event_announcements').update({ deleted_at: new Date().toISOString() }).eq('id', r.id)
+        await supabase
+            .from('telegram_outbound_messages')
+            .update({ deleted_at: new Date().toISOString() })
+            .eq('id', r.id)
         deleted += 1
     }
 
@@ -822,7 +834,7 @@ export async function handlePinAnnouncement(
 
     // Только живое (отправленное, не отменённое/удалённое) сообщение можно (от)закрепить.
     const { data: row } = await supabase
-        .from('map_event_announcements')
+        .from('telegram_outbound_messages')
         .select('id, telegram_chat_id, telegram_message_id')
         .eq('id', announcementId)
         .not('telegram_message_id', 'is', null)
@@ -834,6 +846,219 @@ export async function handlePinAnnouncement(
     const result = await setAnnouncementPinned(supabase, row, body.pin, botToken)
     if (!result.ok) return jsonWithCors({ error: 'telegram_failed', description: result.description }, 502)
     return jsonWithCors({ ok: true, pinned: result.pinned }, 200)
+}
+
+// ───────────────────────────── Новости проекта ─────────────────────────────
+
+/**
+ * Общий guard сабрутов /news-*: проверяет админа, наличие bot-токена, парсит JSON
+ * и валидирует news_id (UUID). Возвращает распарсенное тело либо готовый error-Response.
+ */
+async function requireNewsRequest(
+    supabase: SupabaseClient,
+    req: Request,
+    botToken: string | undefined,
+): Promise<{ body: Record<string, unknown>; newsId: string; botToken: string } | Response> {
+    if (!(await isAdminRequest(supabase, req))) return jsonWithCors({ error: 'unauthorized' }, 401)
+    if (!botToken) return jsonWithCors({ error: 'no_bot_token' }, 500)
+
+    let body: Record<string, unknown>
+    try {
+        body = (await req.json()) as Record<string, unknown>
+    } catch {
+        return jsonWithCors({ error: 'bad_request' }, 400)
+    }
+    const newsId = body.news_id
+    if (typeof newsId !== 'string' || !UUID_RE.test(newsId)) {
+        return jsonWithCors({ error: 'invalid_input' }, 400)
+    }
+    return { body, newsId, botToken }
+}
+
+/** Загружает новость (тело + фото) для отправки/правки. */
+async function loadNewsContext(
+    supabase: SupabaseClient,
+    newsId: string,
+): Promise<{ body: string; photoPath: string | null } | null> {
+    const { data, error } = await supabase
+        .from('map_news')
+        .select('body, photo_path, deleted_at')
+        .eq('id', newsId)
+        .maybeSingle<{ body: string; photo_path: string | null; deleted_at: string | null }>()
+    if (error || !data || data.deleted_at !== null) return null
+    return { body: data.body, photoPath: data.photo_path }
+}
+
+/** Публичный URL фото новости. */
+function newsPhotoPublicUrl(supabase: SupabaseClient, photoPath: string): string {
+    return supabase.storage.from('map-news-photos').getPublicUrl(photoPath).data.publicUrl
+}
+
+/**
+ * Сабрут /news-announce: отправляет новость в выбранные чаты (sendMessage/sendPhoto).
+ * Body: { news_id: uuid, destination_ids: string[] }. Авторизация — JWT администратора.
+ */
+export async function handleAnnounceNews(
+    supabase: SupabaseClient,
+    req: Request,
+    botToken: string | undefined,
+): Promise<Response> {
+    const guard = await requireNewsRequest(supabase, req, botToken)
+    if (guard instanceof Response) return guard
+    const { body, newsId, botToken: token } = guard
+    // destination_ids — суррогатные id назначений (чат+тема); один chat_id может встречаться несколько раз.
+    const destinationIds = body.destination_ids
+    if (
+        !Array.isArray(destinationIds) ||
+        destinationIds.length === 0 ||
+        !destinationIds.every((d) => typeof d === 'string')
+    ) {
+        return jsonWithCors({ error: 'invalid_input' }, 400)
+    }
+
+    const ctx = await loadNewsContext(supabase, newsId)
+    if (!ctx) return jsonWithCors({ error: 'news_not_found' }, 404)
+    if (ctx.body.trim().length === 0) return jsonWithCors({ error: 'empty_body' }, 400)
+
+    // Только переданные назначения, которые есть в telegram_chats и enabled.
+    const { data: chatRows } = await supabase
+        .from('telegram_chats')
+        .select('chat_id, message_thread_id')
+        .eq('enabled', true)
+        .in('id', destinationIds)
+    const validChats = (chatRows ?? []) as Array<{ chat_id: number; message_thread_id: number | null }>
+    if (validChats.length === 0) return jsonWithCors({ error: 'no_valid_chats' }, 400)
+
+    const text = buildNewsText(ctx.body)
+    const photoUrl = ctx.photoPath ? newsPhotoPublicUrl(supabase, ctx.photoPath) : null
+
+    const sent: Array<{ chat_id: number; message_id: number }> = []
+    const failed: Array<{ chat_id: number; error: string }> = []
+
+    for (const { chat_id: chatId, message_thread_id: threadId } of validChats) {
+        // В форумных группах сообщение адресуется в тему; для обычных чатов ключ не шлём.
+        const thread = typeof threadId === 'number' ? { message_thread_id: threadId } : {}
+        const apiResult = photoUrl
+            ? await callTelegramApi(
+                  'sendPhoto',
+                  { chat_id: chatId, ...thread, photo: photoUrl, caption: text, parse_mode: 'HTML' },
+                  token,
+              )
+            : await callTelegramApi(
+                  'sendMessage',
+                  { chat_id: chatId, ...thread, text, parse_mode: 'HTML', disable_web_page_preview: true },
+                  token,
+              )
+
+        const messageId =
+            apiResult.ok && apiResult.result && typeof apiResult.result === 'object'
+                ? ((apiResult.result as { message_id?: number }).message_id ?? null)
+                : null
+
+        if (apiResult.ok && messageId !== null) {
+            await supabase.from('telegram_outbound_messages').insert({
+                news_id: newsId,
+                telegram_chat_id: chatId,
+                message_thread_id: threadId,
+                telegram_message_id: messageId,
+                message_text: text,
+                body_text: ctx.body,
+                photo_path: ctx.photoPath,
+                sent_at: new Date().toISOString(),
+            })
+            sent.push({ chat_id: chatId, message_id: messageId })
+        } else {
+            const errText = apiResult.description ?? 'send_failed'
+            await supabase.from('telegram_outbound_messages').insert({
+                news_id: newsId,
+                telegram_chat_id: chatId,
+                message_thread_id: threadId,
+                message_text: text,
+                body_text: ctx.body,
+                photo_path: ctx.photoPath,
+                send_error: errText,
+            })
+            failed.push({ chat_id: chatId, error: errText })
+        }
+    }
+
+    return jsonWithCors({ sent, failed }, 200)
+}
+
+/**
+ * Сабрут /news-announce-edit: меняет текст во ВСЕХ живых сообщениях новости.
+ * Берёт актуальное тело из map_news (источник истины). Body: { news_id: uuid }.
+ */
+export async function handleEditNews(
+    supabase: SupabaseClient,
+    req: Request,
+    botToken: string | undefined,
+): Promise<Response> {
+    const guard = await requireNewsRequest(supabase, req, botToken)
+    if (guard instanceof Response) return guard
+    const { newsId, botToken: token } = guard
+
+    const ctx = await loadNewsContext(supabase, newsId)
+    if (!ctx) return jsonWithCors({ error: 'news_not_found' }, 404)
+
+    const text = buildNewsText(ctx.body)
+    const rows = await listLiveAnnouncements(supabase, 'news_id', newsId)
+
+    let edited = 0
+    const failed: Array<{ chat_id: number; error: string }> = []
+    for (const r of rows) {
+        const editResult = await editAnnouncementContent(r, text, token)
+        if (editResult.ok) {
+            await supabase
+                .from('telegram_outbound_messages')
+                .update({ message_text: text, body_text: ctx.body })
+                .eq('id', r.id)
+            edited += 1
+        } else {
+            failed.push({ chat_id: r.telegram_chat_id, error: editResult.description ?? 'edit_failed' })
+            // Сообщение удалено из чата → выводим из живых, иначе «призрак» вечно в failed.
+            if (isMessageGoneError(editResult.description)) await markOutboundDeleted(supabase, r.id)
+        }
+    }
+
+    return jsonWithCors({ edited, failed }, 200)
+}
+
+/**
+ * Сабрут /news-announce-delete: удаляет сообщения новости из Telegram (deleteMessage)
+ * и помечает строки deleted_at. Строки остаются в БД для истории. Body: { news_id: uuid }.
+ */
+export async function handleDeleteNews(
+    supabase: SupabaseClient,
+    req: Request,
+    botToken: string | undefined,
+): Promise<Response> {
+    const guard = await requireNewsRequest(supabase, req, botToken)
+    if (guard instanceof Response) return guard
+    const { newsId, botToken: token } = guard
+
+    const rows = await listLiveAnnouncements(supabase, 'news_id', newsId)
+
+    let deleted = 0
+    for (const r of rows) {
+        // Telegram возвращает ok=true даже если сообщение уже удалено — считаем успехом.
+        const delResult = await callTelegramApi(
+            'deleteMessage',
+            { chat_id: r.telegram_chat_id, message_id: r.telegram_message_id },
+            token,
+        )
+        if (!delResult.ok) {
+            console.info('[telegram-location-bot] deleteMessage (news) пропущен', {
+                chat_id: r.telegram_chat_id,
+                message_id: r.telegram_message_id,
+                description: delResult.description,
+            })
+        }
+        await markOutboundDeleted(supabase, r.id)
+        deleted += 1
+    }
+
+    return jsonWithCors({ deleted }, 200)
 }
 
 // ──────────────────────────────────────────────────────────────────────────────

--- a/supabase/functions/telegram-location-bot/_pure.test.ts
+++ b/supabase/functions/telegram-location-bot/_pure.test.ts
@@ -2,6 +2,7 @@ import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
 import {
     buildAnnouncementHeader,
     buildAnnouncementText,
+    buildNewsText,
     buildRsvpKeyboard,
     escapeHtml,
     formatParticipateButtonLabel,
@@ -118,6 +119,11 @@ Deno.test('buildAnnouncementText: шапка + тело (с escape) либо т�
     assertEquals(withBody, 'Покатушка · <b>T</b>\n\nпривет &lt;b&gt;')
     const noBody = buildAnnouncementText(event, 'not-a-date', '   ')
     assertEquals(noBody, 'Покатушка · <b>T</b>')
+})
+
+Deno.test('buildNewsText: тримит и экранирует HTML, без шапки', () => {
+    assertEquals(buildNewsText('  Привет <b>мир</b> & все  '), 'Привет &lt;b&gt;мир&lt;/b&gt; &amp; все')
+    assertEquals(buildNewsText('   '), '')
 })
 
 Deno.test('getMessageWithLocation: приоритет message → edited → channel', () => {

--- a/supabase/functions/telegram-location-bot/_pure.ts
+++ b/supabase/functions/telegram-location-bot/_pure.ts
@@ -313,3 +313,11 @@ export function buildAnnouncementText(event: AnnouncementEvent, startsAtIso: str
     const trimmed = body.trim()
     return trimmed ? `${header}\n\n${escapeHtml(trimmed)}` : header
 }
+
+/**
+ * Текст новости проекта для Telegram: свободное тело админа, экранированное для parse_mode HTML.
+ * Без шапки и кнопок (в отличие от анонса события) — новость это просто текст (+ опц. фото).
+ */
+export function buildNewsText(body: string): string {
+    return escapeHtml(body.trim())
+}

--- a/supabase/functions/telegram-location-bot/index.ts
+++ b/supabase/functions/telegram-location-bot/index.ts
@@ -10,6 +10,9 @@ import {
     handleDeleteAnnouncements,
     handleEditAnnouncements,
     handlePinAnnouncement,
+    handleAnnounceNews,
+    handleEditNews,
+    handleDeleteNews,
     handleInlineQuery,
     handleLocationUpdate,
     jsonWithCors,
@@ -38,7 +41,10 @@ Deno.serve(async (req) => {
         requestPath.endsWith('/announce-cancel') ||
         requestPath.endsWith('/announce-edit') ||
         requestPath.endsWith('/announce-delete') ||
-        requestPath.endsWith('/announce-pin')
+        requestPath.endsWith('/announce-pin') ||
+        requestPath.endsWith('/news-announce') ||
+        requestPath.endsWith('/news-announce-edit') ||
+        requestPath.endsWith('/news-announce-delete')
 
     // CORS preflight для сабрутов админки (functions.invoke шлёт OPTIONS перед POST).
     if (req.method === 'OPTIONS' && isAnnounceRoute) {
@@ -62,6 +68,15 @@ Deno.serve(async (req) => {
         }
         if (requestPath.endsWith('/announce-pin')) {
             return handlePinAnnouncement(supabase, req, announceBotToken)
+        }
+        if (requestPath.endsWith('/news-announce-edit')) {
+            return handleEditNews(supabase, req, announceBotToken)
+        }
+        if (requestPath.endsWith('/news-announce-delete')) {
+            return handleDeleteNews(supabase, req, announceBotToken)
+        }
+        if (requestPath.endsWith('/news-announce')) {
+            return handleAnnounceNews(supabase, req, announceBotToken)
         }
         return handleAnnounceEventDate(supabase, req, announceBotToken, announceMapBaseUrl)
     }

--- a/supabase/migrations/20260627120000_create_project_news_suite.sql
+++ b/supabase/migrations/20260627120000_create_project_news_suite.sql
@@ -1,0 +1,123 @@
+-- Функционал «Новости проекта»: свободный текст (+ опциональное фото), рассылаемый
+-- в выбранные telegram_chats, с правкой и удалением отправленного.
+--
+-- Архитектурно объединяем исходящие сообщения бота в одну таблицу
+-- telegram_outbound_messages (переименование существующей map_event_announcements),
+-- с полиморфной привязкой: event_date_id ЛИБО news_id. Так анонсы событий и новости
+-- живут в общей таблице — единый маппинг (chat_id, message_id) → отправитель,
+-- общий send/edit/delete. RSVP/cancel/pin остаются специфичны для событий.
+
+-- ───────────────────────── map_news ─────────────────────────
+-- Новость = черновик в БД: тело (свободный текст) + опциональное фото.
+-- Живёт только в Telegram (публичного чтения с карты нет); deleted_at — мягкое удаление.
+CREATE TABLE map_news (
+    id uuid DEFAULT gen_random_uuid() PRIMARY KEY,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    body text DEFAULT ''::text NOT NULL,
+    photo_path text,
+    deleted_at timestamp with time zone
+);
+COMMENT ON TABLE map_news IS 'Новости проекта для рассылки в Telegram-чаты (черновик + история отправок)';
+COMMENT ON COLUMN map_news.body IS 'Свободный текст новости (без HTML-эскейпа) — источник истины для отправки и правки';
+COMMENT ON COLUMN map_news.photo_path IS 'Путь к изображению новости в Storage (NULL — без картинки)';
+COMMENT ON COLUMN map_news.deleted_at IS 'Время мягкого удаления новости из админки (строка остаётся для истории)';
+
+CREATE INDEX map_news_created_at_idx ON map_news (created_at DESC);
+
+ALTER TABLE map_news ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Администраторы читают новости"
+    ON map_news
+    FOR SELECT TO authenticated
+    USING (EXISTS (SELECT 1 FROM map_admin_users m WHERE m.user_id = auth.uid()));
+CREATE POLICY "Администраторы создают новости"
+    ON map_news
+    FOR INSERT TO authenticated
+    WITH CHECK (EXISTS (SELECT 1 FROM map_admin_users m WHERE m.user_id = auth.uid()));
+CREATE POLICY "Администраторы обновляют новости"
+    ON map_news
+    FOR UPDATE TO authenticated
+    USING (EXISTS (SELECT 1 FROM map_admin_users m WHERE m.user_id = auth.uid()))
+    WITH CHECK (EXISTS (SELECT 1 FROM map_admin_users m WHERE m.user_id = auth.uid()));
+CREATE POLICY "Администраторы удаляют новости"
+    ON map_news
+    FOR DELETE TO authenticated
+    USING (EXISTS (SELECT 1 FROM map_admin_users m WHERE m.user_id = auth.uid()));
+
+-- ───────────── map_event_announcements → telegram_outbound_messages ─────────────
+-- Переименование сохраняет данные, RLS-политику и FK event_date_id. Затем обобщаем:
+-- event_date_id становится nullable, добавляем news_id; ровно один из них должен быть задан.
+ALTER TABLE map_event_announcements RENAME TO telegram_outbound_messages;
+
+-- Имена индексов и constraint'ов при RENAME TABLE не меняются — приводим к новому неймингу.
+ALTER TABLE telegram_outbound_messages
+    RENAME CONSTRAINT map_event_announcements_chat_msg_key TO telegram_outbound_messages_chat_msg_key;
+ALTER INDEX map_event_announcements_event_date_id_idx RENAME TO telegram_outbound_messages_event_date_id_idx;
+ALTER INDEX map_event_announcements_msg_lookup_idx RENAME TO telegram_outbound_messages_msg_lookup_idx;
+
+-- event_date_id больше не обязателен (у новостей он NULL).
+ALTER TABLE telegram_outbound_messages ALTER COLUMN event_date_id DROP NOT NULL;
+
+-- Привязка к новости (полиморфно с event_date_id).
+ALTER TABLE telegram_outbound_messages
+    ADD COLUMN news_id uuid REFERENCES map_news(id) ON DELETE CASCADE;
+
+-- Ровно один родитель: либо событие, либо новость.
+ALTER TABLE telegram_outbound_messages
+    ADD CONSTRAINT telegram_outbound_messages_one_parent CHECK (
+        (event_date_id IS NOT NULL AND news_id IS NULL)
+        OR (event_date_id IS NULL AND news_id IS NOT NULL)
+    );
+
+CREATE INDEX telegram_outbound_messages_news_id_idx ON telegram_outbound_messages (news_id);
+
+COMMENT ON TABLE telegram_outbound_messages IS 'Исходящие сообщения бота: анонсы событий (event_date_id) и новости проекта (news_id) — единый маппинг (chat_id, message_id) → отправитель';
+COMMENT ON COLUMN telegram_outbound_messages.event_date_id IS 'Дата события, к которой относится анонс (NULL для новостей)';
+COMMENT ON COLUMN telegram_outbound_messages.news_id IS 'Новость, к которой относится сообщение (NULL для анонсов событий)';
+
+-- ───────────────────────── Storage: map-news-photos ─────────────────────────
+-- Публичное чтение (Telegram тянет фото по публичному URL), запись — только администраторы.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+    'map-news-photos',
+    'map-news-photos',
+    true,
+    10485760,
+    ARRAY['image/jpeg', 'image/png', 'image/webp']
+)
+ON CONFLICT (id) DO UPDATE
+SET
+    public = EXCLUDED.public,
+    file_size_limit = EXCLUDED.file_size_limit,
+    allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+CREATE POLICY "Public read access for map news photos"
+    ON storage.objects
+    FOR SELECT
+    TO public
+    USING (bucket_id = 'map-news-photos');
+
+CREATE POLICY "Администраторы загружают фото новостей"
+    ON storage.objects
+    FOR INSERT TO authenticated
+    WITH CHECK (
+        bucket_id = 'map-news-photos'
+        AND EXISTS (SELECT 1 FROM public.map_admin_users m WHERE m.user_id = auth.uid())
+    );
+CREATE POLICY "Администраторы обновляют фото новостей в storage"
+    ON storage.objects
+    FOR UPDATE TO authenticated
+    USING (
+        bucket_id = 'map-news-photos'
+        AND EXISTS (SELECT 1 FROM public.map_admin_users m WHERE m.user_id = auth.uid())
+    )
+    WITH CHECK (
+        bucket_id = 'map-news-photos'
+        AND EXISTS (SELECT 1 FROM public.map_admin_users m WHERE m.user_id = auth.uid())
+    );
+CREATE POLICY "Администраторы удаляют фото новостей в storage"
+    ON storage.objects
+    FOR DELETE TO authenticated
+    USING (
+        bucket_id = 'map-news-photos'
+        AND EXISTS (SELECT 1 FROM public.map_admin_users m WHERE m.user_id = auth.uid())
+    );


### PR DESCRIPTION
## Summary

- **Новости проекта** — новый раздел `/admin/news`: создание новости (текст + опциональное фото), рассылка в выбранные Telegram-чаты, обновление текста во всех отправленных сообщениях и удаление их из Telegram.
- Edge-сабруты `telegram-location-bot`: `/news-announce`, `/news-announce-edit`, `/news-announce-delete`.
- Миграция: таблица `map_news`, Storage-бакет `map-news-photos`.
- **Рефакторинг**: исходящие сообщения бота объединены в единую таблицу `telegram_outbound_messages` (переименование `map_event_announcements` + полиморфная привязка `event_date_id` | `news_id`, CHECK «ровно один родитель»). Анонсы событий и новости используют общие helpers (`announceClient`, `listLiveAnnouncements`, `editAnnouncementContent`, `markOutboundDeleted`).

## Test plan

- [x] `npm run lint` — ✅
- [x] `npx tsc -b --noEmit` — ✅
- [x] `npm run test` — ✅ (476 unit)
- [x] `npm run test:functions` (Deno) — ✅ (60)
- [x] Проверено вручную в браузере: вход в админку → создание новости → отправка в тестовый чат (доставлено, message_id записан) → список. Правка/удаление в Telegram не прогонялись вживую (внешний эффект), покрыты unit-тестами.

> ⚠️ Миграция переименовывает `map_event_announcements` → `telegram_outbound_messages`. CI применяет миграции до деплоя — порядок выдержан.

🤖 Generated with [Claude Code](https://claude.com/claude-code)