### PR TITLE
docs: обновить CLAUDE.md под текущее состояние проекта

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,22 +4,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-PWA-карта для райдеров на моноколёсах (EUC) в Алматы — live at **map.euc.kz**. Точки встреч, розетки, маршруты, велодорожки и live-геопозиции из Telegram-чатов.
+PWA-карта для райдеров на моноколёсах (EUC) в Алматы — live at **map.euc.kz**. Точки встреч, розетки, маршруты, велодорожки и live-геопозиции из Telegram-чатов. Плюс события (анонсы поездок с RSVP через Telegram) и новости проекта.
 
 ## Stack
 
 - **React 19** + **TypeScript 6** (strict) + **Vite 8** + **Tailwind CSS 4** (`@tailwindcss/vite`)
 - **Mapbox GL JS 3** — карта; **react-router-dom 7** — SPA-роутинг; **Font Awesome 7** — иконки
 - **Supabase** — PostgreSQL + RLS + Realtime + Storage + Deno Edge Functions
-- **Vitest 4** + **RTL 16** + **jsdom** — unit-тесты; **Playwright** — e2e
+- **Vitest 4** + **RTL 16** + **jsdom** — unit-тесты; **Playwright** — e2e; **Deno test** — Edge Functions
 - **Husky 9** — pre-commit хук; **ESLint 10** + **Prettier** — качество кода
+- **typograf** — типографика русских текстов (см. `src/utils/typograf.ts`)
 
 ## Commands
 
 ```bash
 npm run dev          # Vite dev server (localhost:5173; host: true — доступен по сети)
-npm run build        # tsc -b && vite build (type-check + bundle)
+npm run build        # vite build (только бандл, БЕЗ type-check)
+npm run build:check  # tsc -b && vite build (type-check + bundle)
 npm run lint         # ESLint (TypeScript strict + React hooks)
+npm run format       # prettier --write .
+npm run format:check # prettier --check . (то, что проверяет CI и хук)
 npm run test         # Vitest (run once)
 npm run preview      # Preview production build locally
 ```
@@ -30,9 +34,11 @@ npm run preview      # Preview production build locally
 npx vitest run src/utils/hashNav.test.ts
 ```
 
-**Pre-commit хук** (`.husky/pre-commit`) запускает автоматически: `lint → tsc --noEmit → test → build`.
+E2E тесты: `npm run test:e2e` / `npm run test:e2e:ui` (перед запуском авто-`build:e2e` со stub-env).
+Тесты Edge Functions (Deno): `npm run test:functions` (`deno test --allow-net supabase/functions/`).
 
-E2E тесты: `npm run test:e2e` / `npm run test:e2e:ui`
+**Pre-commit хук** (`.husky/pre-commit`) запускает автоматически: `lint → format:check → tsc -b --noEmit → test → test:functions (если есть deno) → build → test:e2e`.
+**CI** (`.github/workflows/test.yml`) дублирует те же гейты: lint, format:check, type-check, unit, Deno-функции, e2e.
 
 ## Environment
 
@@ -57,7 +63,7 @@ VITE_TELEGRAM_MAX_ACCURACY_METERS=100
 
 ## Language
 
-UI-тексты, сообщения пользователю, комментарии в коде — **русский**.
+UI-тексты, сообщения пользователю, комментарии в коде — **русский**. Пользовательские длинные тексты (описания событий/новостей и т.п.) прогонять через типографику — `src/utils/typograf.ts`.
 
 ## Code Style
 
@@ -86,23 +92,29 @@ UI-тексты, сообщения пользователю, комментар
 
 ```
 src/
+├── app/           # Роутовые оболочки: MapShell (lazy-грузит EucMap), NotFound
 ├── components/    # UI только — никакой бизнес-логики
+│   ├── ui/            # Примитивы: Badge, FilterChips, SearchInput, ToggleSwitch
+│   └── icons/         # Кастомные SVG-иконки (IconTelegram)
 ├── hooks/         # Состояние, эффекты, загрузка данных
-├── lib/           # env.ts, supabase.ts, mapLayers.ts
+├── lib/           # env.ts, supabase.ts, mapLayers.ts, analytics.ts
 ├── utils/         # Чистые функции без React/Mapbox (все покрыты тестами)
-├── constants/     # Единственный источник LAYER_IDS, SOURCE_IDS, COLORS, MAP_CENTER
+├── constants/     # LAYER_IDS/SOURCE_IDS/COLORS/MAP_CENTER (index.ts), layerVisibility.ts, mapLayerRegistry.ts
 ├── types/         # geojson.ts, supabase.ts, velojol.ts — реэкспорт через index.ts
 ├── data/          # almaty.json — статичный GeoJSON велодорожек (Velojol)
 ├── test/          # setup.ts для Vitest + jsdom
 └── admin/         # Lazy-loaded по /admin, Supabase Auth + map_admin_users
-    ├── pages/         # PointEditPage, RouteEditPage, SubmissionsPage, GeoPage, PointsPage, RoutesPage
-    ├── components/    # PointForm, PhotoManager, AdminRoutePolylineMap, ConfirmDialog, ...
+    ├── pages/         # Point/Route/Submissions/Geo + Events, News, TelegramChats (+ AdminLoginPage)
+    ├── components/    # PointForm, PhotoManager, EventForm, EventDatesManager, EventAnnounceModal,
+    │                  #   NewsAnnounceManager, AnnouncementMessagesList, ConfirmDialog, ...
     ├── hooks/         # useAdminAuth, useCoordinateHistory, useUndoRedoHotkeys, useAdminListLoader
-    ├── lib/adminApi/  # CRUD: points, routes, photos, submissions, geo; types, parsers, query
+    ├── lib/adminApi/  # CRUD: points, routes, photos, submissions, geo, events, news, telegramChats;
+    │                  #   eventAnnouncements, newsAnnouncements, announceClient; types, parsers, query
+    ├── utils/         # formatAdminDate
     └── route-editor/  # routeGeometry.ts, routeValidation.ts (геометрия и валидация маршрута)
 supabase/
-├── migrations/    # 16 PostgreSQL-миграций (все таблицы + RLS + индексы)
-├── functions/     # telegram-location-bot (Deno, webhook-обработчик)
+├── migrations/    # 26 PostgreSQL-миграций (все таблицы + RLS + индексы + RPC)
+├── functions/     # telegram-location-bot (Deno): index.ts + _handlers.ts + _pure.ts (+ *.test.ts)
 └── schema.sql     # Полный экспорт схемы БД
 ```
 
@@ -138,8 +150,17 @@ Telegram realtime:
 5. `useMapSelectionSync` — синхронизирует URL ↔ выбранная фича
 6. `useMapPopup` — управляет Mapbox popup
 7. `useGeolocateControl`, `useUserGeolocation`, `useDeviceCompassHeading` — геолокация
+8. `useEvents`, `useTelegramAvatars`, `useMapPadding`, `useDraftPointFlow` — события, аватары, паддинг под сайдбары, флоу добавления точки
 
-Рендерит: `LayerControls`, `FeatureSidebar`, `PopupContent`, `AddPointPanel`, `MapOverlayButtons`, `MapNotificationModals`, `PwaPrompts`.
+Рендерит: `LayerControls`, `BottomTabBar`, `LiveActivityBar`, `PointListSidebar`, `RouteListSidebar`, `PopupContent`, `AddPointPanel`, `MapFeatureInfoModal`, `ProjectInfoModal`, `MapNotificationModals`, `RadarModal`, `EventsScreen`, `EventDetailScreen`. `PwaPrompts` рендерится в `App.tsx`.
+
+### Routing & Screens (`src/App.tsx`, `src/app/`)
+
+- `BrowserRouter basename={import.meta.env.BASE_URL}` — все пути реальные (не hash).
+- Публичные пути `/`, `/radar`, `/events`, `/events/:eventId`, `/help`, `/m/:type/:id` рендерят один и тот же `MapShell` (lazy-грузит `EucMap`). Экраны/модалки (радар, события, помощь) — оверлеи над картой; `EucMap` читает `useLocation()` и показывает нужный экран, чтобы карта не размонтировалась при навигации.
+- **Нижняя навигация** — `BottomTabBar`: Точки / Маршруты / Добавить / События / Радар / Помощь. Бейджи (непрочитанные события) — через `useEvents` + `eventsReadStore`.
+- `/admin/*` — отдельная ветка под `AdminShell` с lazy-страницами (`src/admin/lazyAdminPages.ts`): submissions, point(s), route(s), event(s), news, telegram-chats, geo.
+- Неизвестный путь вне `/admin` → `NotFound` (`src/app/NotFound.tsx`).
 
 ### Feature State (нет DOM-ререндеров)
 
@@ -167,6 +188,8 @@ map.setFeatureState({ source, id }, { selected: true })
 - `FEATURE_TYPE_LABELS`, `POINT_FLAG_LABELS` — русские подписи
 - `MAPBOX_STYLES` (`streets`, `satellite`), тип `BaseMapStyle`, тип `LayerKey`
 - `MAP_CENTER` (`[76.904848, 43.226807]`), `MAP_ZOOM_DEFAULT` (12), `MAP_ZOOM_FOCUS` (15)
+- `layerVisibility.ts` — тип `LayerVisibility` и дефолты видимости слоёв (стор `useLayerVisibilityStore`)
+- `mapLayerRegistry.ts` — `LAYER_KEY_TO_MAP_LAYER_IDS` + `applyVisibilityToMapLayers(map, visibility)` (у telegram два слоя — треки + маркеры — под одной кнопкой)
 
 ### GeoJSON & Types (`src/types/`)
 
@@ -194,21 +217,32 @@ map.setFeatureState({ source, id }, { selected: true })
 
 ### Telegram Bot (Edge Function)
 
-`supabase/functions/telegram-location-bot/index.ts` — Deno runtime. Принимает webhook `POST`, валидирует secret-токен, сохраняет геопозицию в `telegram_locations`, кеширует аватар в `telegram_profiles` + Storage. URL аватара санируется (bot-токен вырезается перед записью).
+`supabase/functions/telegram-location-bot/` — Deno runtime. `index.ts` — роутинг webhook'ов; `_handlers.ts` — обработчики (I/O с Telegram/Supabase); `_pure.ts` — чистые хелперы (легко тестируются). Отдельные тесты `_handlers.test.ts` / `_pure.test.ts` (`npm run test:functions`).
+
+Функционал бота вырос за пределы геолокации:
+
+- **Геопозиция**: webhook `POST`, валидация secret-токена, запись в `telegram_locations`, кеш аватара в `telegram_profiles` + Storage (URL санируется — bot-токен вырезается перед записью).
+- **RSVP событий**: `handleCallbackQuery` — inline-кнопки записи на дату события → `map_event_participants`, `answerCallbackQuery` в коротком окне (аватар не запрашиваем, добьёт `/backfill`).
+- **Анонсы/новости**: сабруты рассылки, правки, удаления, отмены и пина сообщений (`handleAnnounceEventDate`, `handleAnnounceNews`, `handleEdit*`, `handleDelete*`, `handleCancelAnnouncements`, `handlePinAnnouncement`) — пишут в `telegram_outbound_messages`. Админ-действия защищены `isAdminRequest`.
+- Ссылка на событие в анонсе — строго `/events/:id` (сегмент `EVENTS_PATH_PREFIX`), НЕ `/m/event/:id`.
 
 ### Admin Section (`/admin`)
 
-Lazy-loaded, доступ — Supabase Auth + запись в `map_admin_users`. Структура:
+Lazy-loaded (`lazyAdminPages.ts`), доступ — Supabase Auth + запись в `map_admin_users`. Структура:
 
-- **adminApi**: `listPoints/getPoint/createPoint/updatePoint/togglePointDisabled/deletePoint`, аналогично для routes; `listSubmissions/approveSubmission/rejectSubmission`; `getAdminGeoData`; `uploadPhoto/deletePhoto`
-- **route-editor**: геометрия и валидация вершин маршрута
-- Undo/redo координат: `useCoordinateHistory` + `useUndoRedoHotkeys`
-- Кнопка «Открыть на сайте» в edit-страницах: `${import.meta.env.BASE_URL}${buildMapDeepLinkPath(...)}`
+- **adminApi**: CRUD для points, routes, events, news; `listSubmissions/approveSubmission/rejectSubmission`; `getAdminGeoData`; `uploadPhoto/deletePhoto`; `telegramChats`; `eventAnnouncements`/`newsAnnouncements` + `announceClient` (вызов Edge-сабрутов рассылки).
+- **События**: `EventForm`, `EventDatesManager` (даты поездки), `EventAnnounceModal` + `AnnouncementMessagesList` (рассылка анонса в чаты, счётчик RSVP, правка/удаление/пин).
+- **Новости**: `NewsAnnounceManager` + `NewsMessagesList` (рассылка новости в выбранные чаты).
+- **route-editor**: геометрия и валидация вершин маршрута. Undo/redo координат: `useCoordinateHistory` + `useUndoRedoHotkeys`.
+- Кнопка «Открыть на сайте» в edit-страницах: `${import.meta.env.BASE_URL}${buildMapDeepLinkPath(...)}` (для события — `buildEventDetailPath`).
 
 ### Deployment
 
 - **GitHub Pages** (`map.euc.kz`) — static SPA; `GITHUB_PAGES=true` → Vite `base = /map.euc/`
-- **CI/CD**: `.github/workflows/deploy.yml` — Supabase migrate → build → deploy → Telegram notification
+- **Workflows** (`.github/workflows/`):
+    - `deploy.yml` — Supabase migrate → build → deploy → Telegram notification
+    - `test.yml` — lint / format:check / type-check / unit / Deno-функции / e2e (+ Telegram-нотификация о падении)
+    - `backup.yml` — ежедневный бэкап Supabase (БД + Storage) в S3 (Selectel); `pg_dump` 17 под PG 17
 - **Локально**: Valet proxy `map.euc.test` → `localhost:5173`
 
 ### PWA


### PR DESCRIPTION
## Что изменилось

Актуализировал `CLAUDE.md` под текущее состояние кодовой базы — со времени последней версии добавились крупные фичи (события с RSVP, новости, рассылки в Telegram) и изменилась структура/команды.

### Обновления
- **Commands**: `npm run build` теперь только `vite build` (без type-check); добавлены `build:check`, `format`, `format:check`, `test:functions`. Уточнён pre-commit хук и CI-гейты (`lint → format:check → tsc → test → test:functions → build → test:e2e`).
- **Directory Structure**: добавлены `src/app/` (MapShell, NotFound), `src/components/ui/`, `src/components/icons/`, `src/admin/utils/`; расширены `admin/pages` и `adminApi` (events, news, telegramChats, announcements). Миграций теперь 26 (было 16). Функция бота разбита на `index.ts` / `_handlers.ts` / `_pure.ts`.
- **Routing & Screens**: новый раздел про `BrowserRouter`, пути `/radar`, `/events`, `/events/:id`, `/help`, `MapShell`, `BottomTabBar` и оверлейные экраны.
- **Main Component**: обновлён список хуков и рендеримых компонентов `EucMap`.
- **Constants**: добавлены `layerVisibility.ts`, `mapLayerRegistry.ts`.
- **Telegram Bot**: описан выросший функционал — RSVP событий, рассылки/правки/удаления анонсов и новостей.
- **Admin / Deployment**: события и новости в админке; добавлены workflows `test.yml` и `backup.yml`.
- **Stack / Language**: добавлены Deno-тесты и `typograf` для типографики.

Изменения только в `CLAUDE.md` — код не затронут.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H7B3suGmcsDvMUf9Apd5Hc)_