### PR TITLE
ИИ-помощник в админке: улучшение названий/описаний через OpenAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,7 @@ VITE_TELEGRAM_MAX_ACCURACY_METERS=100
 
 # Edge Function `telegram-location-bot` (supabase secrets, не Vite):
 # TELEGRAM_BACKFILL_SECRET=  # обязателен для POST .../backfill; см. README
+
+# Edge Function `ai-assist` (supabase secrets, не Vite; заливка: npm run secrets:sync):
+# OPENAI_API_KEY=  # обязателен для кнопки «Улучшить с ИИ» в админке
+# OPENAI_MODEL=    # опционально, по умолчанию gpt-5-mini

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,8 @@ jobs:
           supabase db push
           # --no-verify-jwt: webhook Telegram без заголовка Authorization; --use-api: сборка на стороне API без Docker на раннере
           supabase functions deploy telegram-location-bot --no-verify-jwt --use-api
+          # --no-verify-jwt: OPTIONS-preflight браузера идёт без Authorization; авторизация — внутри (JWT + map_admin_users)
+          supabase functions deploy ai-assist --no-verify-jwt --use-api
 
   deploy:
     # Не зависит от supabase: миграции БД/edge-функций и сборка статики Pages независимы —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,7 @@ src/
     └── route-editor/  # routeGeometry.ts, routeValidation.ts (геометрия и валидация маршрута)
 supabase/
 ├── migrations/    # 16 PostgreSQL-миграций (все таблицы + RLS + индексы)
-├── functions/     # telegram-location-bot (Deno, webhook-обработчик)
+├── functions/     # telegram-location-bot (webhook бота), ai-assist (OpenAI-помощник админки)
 └── schema.sql     # Полный экспорт схемы БД
 ```
 
@@ -197,6 +197,10 @@ map.setFeatureState({ source, id }, { selected: true })
 ### Telegram Bot (Edge Function)
 
 `supabase/functions/telegram-location-bot/index.ts` — Deno runtime. Принимает webhook `POST`, валидирует secret-токен, сохраняет геопозицию в `telegram_locations`, кеширует аватар в `telegram_profiles` + Storage. URL аватара санируется (bot-токен вырезается перед записью).
+
+### AI Assist (Edge Function)
+
+`supabase/functions/ai-assist/` — улучшение названия/описания точек и маршрутов через OpenAI Responses API + `web_search` (см. [docs/admin.md](docs/admin.md), раздел «ИИ-помощник»). Билдер промпта в `_pure.ts` — копия `src/admin/utils/aiAssistPrompt.ts`, правки синхронизировать. Секреты: `OPENAI_API_KEY`, `OPENAI_MODEL` (опционально).
 
 ### Admin Section (`/admin`)
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ SPA на GitHub Pages: в `dist/` появляется `404.html` (копия `i
       TELEGRAM_BACKFILL_SECRET=<другой_секрет_только_для_backfill>
     ```
     Опционально: `TELEGRAM_BACKFILL_MAX_PROFILES` — лимит профилей за один вызов backfill (по умолчанию 500).
+    Альтернатива: заполнить эти переменные в `.env.local` и выполнить `npm run secrets:sync` — скрипт зальёт все заполненные секреты edge-функций разом.
 2. Задеплойте функцию (на проде при каждом push в `main` это делает GitHub Actions; вручную — например для первого запуска или отладки):
     ```bash
     supabase functions deploy telegram-location-bot --no-verify-jwt --use-api
@@ -276,6 +277,22 @@ curl -X POST "https://<project-ref>.supabase.co/functions/v1/telegram-location-b
 - **`callback_query`**: нажатие «Участвую» в любом чате — toggle участия по `telegram_user_id` (повторный тап убирает запись), счётчик в подписи кнопки обновляется. Профиль участника при необходимости создаётся в `telegram_profiles` (без аватара — его добьёт backfill).
 
 Список чатов для рассылки хранится в таблице `telegram_chats` (управляется в админке `/admin/telegram-chats`, не через env). Участники — в `map_event_participants`, отправленные сообщения — в `telegram_outbound_messages` (общая таблица для анонсов событий и новостей проекта). Новых секретов не требуется: используются существующие `TELEGRAM_BOT_TOKEN`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`. Подробно: [docs/telegram-bot.md](docs/telegram-bot.md).
+
+## ИИ-помощник в админке (ai-assist)
+
+Edge Function `ai-assist` улучшает название/описание точек и маршрутов через OpenAI (Responses API + web-поиск) — кнопка «Улучшить с ИИ» на страницах редактирования в админке. Авторизация — JWT администратора + `map_admin_users`. Подробно: [docs/admin.md](docs/admin.md).
+
+Настройка:
+
+1. Впишите `OPENAI_API_KEY` (и опционально `OPENAI_MODEL`, по умолчанию `gpt-5-mini`) в `.env.local`.
+2. Залейте секреты в Supabase (скрипт заливает все заполненные секреты edge-функций из `.env.local`, включая `TELEGRAM_*`):
+    ```bash
+    npm run secrets:sync
+    ```
+3. Деплой функции — автоматически при push в `main`; вручную:
+    ```bash
+    supabase functions deploy ai-assist --no-verify-jwt --use-api
+    ```
 
 ## Отладка
 

--- a/docs/admin.md
+++ b/docs/admin.md
@@ -73,19 +73,31 @@ Lazy-loaded раздел SPA. Доступ: Supabase Auth (email/пароль) +
 
 ## Компоненты (`src/admin/components/`)
 
-| Компонент                                                                                               | Роль                                                                 |
-| ------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `PointForm`                                                                                             | Форма точки (тип, флаги, координаты с парсингом строки, undo)        |
-| `PhotoManager`                                                                                          | Фото точки: drag&drop, Ctrl+V, сортировка, lightbox (16 unit-тестов) |
-| `AdminPointLocationMap`                                                                                 | Мини-карта с перетаскиваемым маркером точки                          |
-| `AdminRoutePolylineMap`                                                                                 | Интерактивная полилиния маршрута                                     |
-| `AdminGeoMap`                                                                                           | Треки райдеров; разрыв сегмента при > 1 км или > 5 мин               |
-| `RouteVertexEditorList`                                                                                 | Таблица вершин с автопрокруткой к подсвеченной                       |
-| `ConfirmDialog`                                                                                         | Подтверждение (danger/обычный)                                       |
-| `EventForm`, `EventDatesManager`, `EventPhotoManager`, `EventAnnounceModal`, `AnnouncementMessagesList` | События                                                              |
-| `NewsPhotoManager`, `NewsAnnounceManager`, `NewsMessagesList`                                           | Новости                                                              |
+| Компонент                                                                                               | Роль                                                                                  |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `PointForm`                                                                                             | Форма точки (тип, флаги, координаты с парсингом строки, undo)                         |
+| `PhotoManager`                                                                                          | Фото точки: drag&drop, Ctrl+V, сортировка, lightbox (16 unit-тестов)                  |
+| `AdminPointLocationMap`                                                                                 | Мини-карта с перетаскиваемым маркером точки                                           |
+| `AdminRoutePolylineMap`                                                                                 | Интерактивная полилиния маршрута                                                      |
+| `AdminGeoMap`                                                                                           | Треки райдеров; разрыв сегмента при > 1 км или > 5 мин                                |
+| `RouteVertexEditorList`                                                                                 | Таблица вершин с автопрокруткой к подсвеченной                                        |
+| `ConfirmDialog`                                                                                         | Подтверждение (danger/обычный)                                                        |
+| `AiAssistPanel`                                                                                         | Read-only промпт для улучшения названия/описания через внешний ИИ, кнопка копирования |
+| `EventForm`, `EventDatesManager`, `EventPhotoManager`, `EventAnnounceModal`, `AnnouncementMessagesList` | События                                                                               |
+| `NewsPhotoManager`, `NewsAnnounceManager`, `NewsMessagesList`                                           | Новости                                                                               |
 
 `useAdminListLoader<T>` — универсальная загрузка списков (items/loading/error/reload) для всех list-страниц.
+
+### ИИ-помощник (`AiAssistPanel`)
+
+Внизу форм редактирования точки (`PointForm`) и маршрута (`RouteEditPage`) — панель с автоматически собранным промптом для улучшения `title`/`description`: живые значения полей + контекст (тип, координаты, флаги) и требование ответа строгим JSON `{"title", "description", "pois"}` (`pois` — 2–3 точки интереса рядом, информационно для админа). Два сценария:
+
+- **«Скопировать промпт»** — админ вставляет промпт в ChatGPT/Claude вручную;
+- **«Улучшить с ИИ»** — вызов edge-функции `ai-assist` (`improveWithAi` в `src/admin/lib/adminApi/aiAssist.ts` через `functions.invoke`); предложение показывается в панели, «Применить» подставляет `title`/`description` в форму, скроллит к полю «Название» и показывает подсказку «не забудьте Сохранить». Чекбокс «Искать в интернете» (по умолчанию включён) управляет флагом `webSearch`: с ним модель проверяет факты и ищет точки интереса через web-поиск (медленнее, ~45 с), без него — быстрый вызов без POI.
+
+Билдер — чистая функция `buildAiAssistPrompt` в `src/admin/utils/aiAssistPrompt.ts`, намеренно без импортов: её копия живёт в `supabase/functions/ai-assist/_pure.ts` (Deno не импортирует из `src/`), правки синхронизировать в обеих копиях.
+
+Edge-функция `supabase/functions/ai-assist/`: авторизация — JWT админа + `map_admin_users` (как announce-сабруты бота), CORS для браузера, вызов OpenAI **Responses API** с инструментом `web_search` — модель проверяет факты и ищет точки интереса в интернете; JSON-формат не форсируется (конфликтует с поиском), парсер устойчив к markdown-ограждениям. Секреты: `OPENAI_API_KEY` (обязателен), `OPENAI_MODEL` (опционален, по умолчанию `gpt-5-mini`) — заполняются в `.env.local` и заливаются командой `npm run secrets:sync` (`scripts/set-supabase-secrets.sh`, заливает все заполненные секреты edge-функций). Деплой — отдельной строкой в `.github/workflows/deploy.yml` с `--no-verify-jwt` (preflight браузера идёт без Authorization). Валидация входа/ответа — `parseAiAssistEntity`/`parseAiSuggestion`/`extractResponsesOutputText` в `_pure.ts` (deno-тесты `_pure.test.ts`).
 
 ## Первичная настройка администратора
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "preview": "vite preview",
         "generate:pwa-icons": "pwa-asset-generator public/favicon.svg public/icons --icon-only --type png --manifest public/manifest.webmanifest --path-override /icons",
         "generate:pwa-startup": "pwa-asset-generator public/favicon.svg public/icons --splash-only --index index.html --path-override /icons --background \"#0f172a\" --type png",
+        "secrets:sync": "sh scripts/set-supabase-secrets.sh",
         "prepare": "husky"
     },
     "dependencies": {

--- a/scripts/set-supabase-secrets.sh
+++ b/scripts/set-supabase-secrets.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Заливает секреты edge-функций в Supabase из .env.local (только заполненные).
+# SUPABASE_URL и SUPABASE_SERVICE_ROLE_KEY платформа задаёт автоматически — их не трогаем.
+set -e
+cd "$(dirname "$0")/.."
+
+# telegram-location-bot: TELEGRAM_*, MAP_BASE_URL; ai-assist: OPENAI_*
+SECRET_VARS="TELEGRAM_BOT_TOKEN TELEGRAM_WEBHOOK_SECRET TELEGRAM_BACKFILL_SECRET TELEGRAM_BACKFILL_MAX_PROFILES MAP_BASE_URL OPENAI_API_KEY OPENAI_MODEL"
+
+if [ ! -f .env.local ]; then
+    echo "Ошибка: нет .env.local (скопируйте .env.example и заполните)." >&2
+    exit 1
+fi
+
+set -a
+. ./.env.local
+set +a
+
+set --
+for name in $SECRET_VARS; do
+    eval "value=\${$name:-}"
+    if [ -n "$value" ]; then
+        set -- "$@" "$name=$value"
+        echo "→ $name"
+    fi
+done
+
+if [ $# -eq 0 ]; then
+    echo "Ошибка: в .env.local не заполнена ни одна из переменных: $SECRET_VARS" >&2
+    exit 1
+fi
+
+supabase secrets set "$@"
+echo "Обновлено секретов: $#."

--- a/src/admin/components/AiAssistPanel.test.tsx
+++ b/src/admin/components/AiAssistPanel.test.tsx
@@ -1,0 +1,185 @@
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { AiAssistPanel } from './AiAssistPanel'
+import type { AiAssistEntity } from '@/admin/utils/aiAssistPrompt'
+
+vi.mock('@/utils/shareLinks', () => ({
+    copyToClipboard: vi.fn(),
+}))
+
+vi.mock('@/admin/lib/adminApi', () => ({
+    improveWithAi: vi.fn(),
+}))
+
+import { improveWithAi, type AiSuggestion } from '@/admin/lib/adminApi'
+import { copyToClipboard } from '@/utils/shareLinks'
+
+function makeEntity(over: Partial<Extract<AiAssistEntity, { kind: 'point' }>> = {}): AiAssistEntity {
+    return {
+        kind: 'point',
+        pointType: 'point',
+        title: 'Роща Баума',
+        description: 'Тенистая роща.',
+        coordinates: [76.945, 43.238],
+        flagIsMeeting: true,
+        flagHasSocket: false,
+        flagErlan: false,
+        ...over,
+    }
+}
+
+describe('AiAssistPanel', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.mocked(copyToClipboard).mockResolvedValue(true)
+        vi.mocked(improveWithAi).mockResolvedValue({
+            title: 'Улучшенное название',
+            description: 'Улучшенное описание.',
+            pois: [],
+        })
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('показывает промпт с текущим названием в readonly-textarea', () => {
+        render(<AiAssistPanel entity={makeEntity()} />)
+        const textarea = screen.getByRole('textbox')
+        expect(textarea).toHaveProperty('readOnly', true)
+        expect((textarea as HTMLTextAreaElement).value).toContain('Текущее название: «Роща Баума»')
+    })
+
+    it('обновляет промпт при изменении entity (live-значения)', () => {
+        const { rerender } = render(<AiAssistPanel entity={makeEntity()} />)
+        rerender(<AiAssistPanel entity={makeEntity({ title: 'Новое название' })} />)
+        const textarea = screen.getByRole('textbox')
+        expect((textarea as HTMLTextAreaElement).value).toContain('Текущее название: «Новое название»')
+    })
+
+    it('копирует промпт и показывает «Скопировано» на 2,5 секунды', async () => {
+        vi.useFakeTimers()
+        render(<AiAssistPanel entity={makeEntity()} />)
+        const button = screen.getByRole('button', { name: 'Скопировать промпт' })
+        expect(button.getAttribute('type')).toBe('button')
+
+        fireEvent.click(button)
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(0)
+        })
+
+        expect(vi.mocked(copyToClipboard)).toHaveBeenCalledTimes(1)
+        expect(vi.mocked(copyToClipboard).mock.calls[0][0]).toContain('Текущее название: «Роща Баума»')
+        expect(screen.getByRole('button', { name: 'Скопировано' })).toBeDefined()
+
+        act(() => {
+            vi.advanceTimersByTime(2500)
+        })
+        expect(screen.getByRole('button', { name: 'Скопировать промпт' })).toBeDefined()
+    })
+
+    it('не показывает «Скопировано», если копирование не удалось', async () => {
+        vi.mocked(copyToClipboard).mockResolvedValue(false)
+        render(<AiAssistPanel entity={makeEntity()} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Скопировать промпт' }))
+        await waitFor(() => {
+            expect(vi.mocked(copyToClipboard)).toHaveBeenCalledTimes(1)
+        })
+        expect(screen.queryByRole('button', { name: 'Скопировано' })).toBeNull()
+    })
+
+    it('без onApply кнопки «Улучшить с ИИ» нет', () => {
+        render(<AiAssistPanel entity={makeEntity()} />)
+        expect(screen.queryByRole('button', { name: 'Улучшить с ИИ' })).toBeNull()
+    })
+
+    it('«Улучшить с ИИ» → предложение → «Применить» вызывает onApply и скрывает блок', async () => {
+        const onApply = vi.fn()
+        render(<AiAssistPanel entity={makeEntity()} onApply={onApply} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Улучшить с ИИ' }))
+        expect(await screen.findByText('Улучшенное название')).toBeDefined()
+        expect(vi.mocked(improveWithAi)).toHaveBeenCalledWith(makeEntity(), true)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Применить' }))
+        expect(onApply).toHaveBeenCalledWith({
+            title: 'Улучшенное название',
+            description: 'Улучшенное описание.',
+            pois: [],
+        })
+        expect(screen.queryByText('Улучшенное название')).toBeNull()
+        expect(screen.getByText('Подставлено в поля формы — проверьте и нажмите «Сохранить».')).toBeDefined()
+    })
+
+    it('чекбокс «Искать в интернете» выключен → промпт без POI и improveWithAi с webSearch=false', async () => {
+        render(<AiAssistPanel entity={makeEntity()} onApply={vi.fn()} />)
+
+        const checkbox = screen.getByRole('checkbox', { name: /Искать в интернете/ })
+        expect(checkbox).toHaveProperty('checked', true)
+        const textarea = screen.getByRole('textbox')
+        expect((textarea as HTMLTextAreaElement).value).toContain('точки интереса')
+
+        fireEvent.click(checkbox)
+        expect((textarea as HTMLTextAreaElement).value).not.toContain('точки интереса')
+        expect((textarea as HTMLTextAreaElement).value).toContain('{"title": "...", "description": "..."}')
+
+        fireEvent.click(screen.getByRole('button', { name: 'Улучшить с ИИ' }))
+        await screen.findByText('Улучшенное название')
+        expect(vi.mocked(improveWithAi)).toHaveBeenCalledWith(makeEntity(), false)
+    })
+
+    it('показывает точки интереса из предложения', async () => {
+        vi.mocked(improveWithAi).mockResolvedValue({
+            title: 'Улучшенное название',
+            description: 'Улучшенное описание.',
+            pois: ['Кафе «Роща» — кофе и розетки', 'Родник — питьевая вода'],
+        })
+        render(<AiAssistPanel entity={makeEntity()} onApply={vi.fn()} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Улучшить с ИИ' }))
+        expect(await screen.findByText('Точки интереса рядом')).toBeDefined()
+        expect(screen.getByText('Кафе «Роща» — кофе и розетки')).toBeDefined()
+        expect(screen.getByText('Родник — питьевая вода')).toBeDefined()
+    })
+
+    it('«Отклонить» скрывает предложение без onApply-вызова', async () => {
+        const onApply = vi.fn()
+        render(<AiAssistPanel entity={makeEntity()} onApply={onApply} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Улучшить с ИИ' }))
+        fireEvent.click(await screen.findByRole('button', { name: 'Отклонить' }))
+
+        expect(onApply).not.toHaveBeenCalled()
+        expect(screen.queryByText('Улучшенное название')).toBeNull()
+    })
+
+    it('ошибка improveWithAi показывается, кнопка снова активна', async () => {
+        vi.mocked(improveWithAi).mockRejectedValue(new Error('openai_failed'))
+        render(<AiAssistPanel entity={makeEntity()} onApply={vi.fn()} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Улучшить с ИИ' }))
+        expect(await screen.findByText('openai_failed')).toBeDefined()
+        expect(screen.getByRole('button', { name: 'Улучшить с ИИ' })).toHaveProperty('disabled', false)
+    })
+
+    it('во время запроса кнопка показывает «Улучшаю…» и заблокирована', async () => {
+        let resolvePromise: (v: AiSuggestion) => void = () => undefined
+        vi.mocked(improveWithAi).mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolvePromise = resolve
+                }),
+        )
+        render(<AiAssistPanel entity={makeEntity()} onApply={vi.fn()} />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'Улучшить с ИИ' }))
+        expect(screen.getByRole('button', { name: 'Улучшаю…' })).toHaveProperty('disabled', true)
+
+        await act(async () => {
+            resolvePromise({ title: 'Готово название', description: 'Готово описание.', pois: [] })
+            await Promise.resolve()
+        })
+        expect(screen.getByText('Готово название')).toBeDefined()
+    })
+})

--- a/src/admin/components/AiAssistPanel.tsx
+++ b/src/admin/components/AiAssistPanel.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from 'react'
+import { improveWithAi, type AiSuggestion } from '@/admin/lib/adminApi'
+import { copyToClipboard } from '@/utils/shareLinks'
+import { buildAiAssistPrompt, type AiAssistEntity } from '@/admin/utils/aiAssistPrompt'
+
+interface AiAssistPanelProps {
+    entity: AiAssistEntity
+    onApply?: (suggestion: AiSuggestion) => void
+}
+
+/**
+ * Панель «ИИ-помощник»: read-only промпт для улучшения названия/описания объекта
+ * с кнопкой копирования (для ChatGPT/Claude вручную) и кнопкой «Улучшить с ИИ» —
+ * вызов edge-функции ai-assist (OpenAI). Чекбокс «Искать в интернете» управляет
+ * web-поиском (точки интереса, проверка фактов — медленнее).
+ */
+export function AiAssistPanel({ entity, onApply }: AiAssistPanelProps) {
+    const [copied, setCopied] = useState(false)
+    const [webSearch, setWebSearch] = useState(true)
+    const [improving, setImproving] = useState(false)
+    const [suggestion, setSuggestion] = useState<AiSuggestion | null>(null)
+    const [applied, setApplied] = useState(false)
+    const [aiError, setAiError] = useState<string | null>(null)
+    const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+    const appliedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+    useEffect(() => {
+        return () => {
+            if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
+            if (appliedTimerRef.current) clearTimeout(appliedTimerRef.current)
+        }
+    }, [])
+
+    const prompt = buildAiAssistPrompt(entity, { webSearch })
+
+    const handleCopy = async () => {
+        const ok = await copyToClipboard(prompt)
+        if (!ok) return
+        setCopied(true)
+        if (copiedTimerRef.current) clearTimeout(copiedTimerRef.current)
+        copiedTimerRef.current = setTimeout(() => {
+            setCopied(false)
+        }, 2500)
+    }
+
+    const handleImprove = async () => {
+        setImproving(true)
+        setAiError(null)
+        setSuggestion(null)
+        setApplied(false)
+        try {
+            setSuggestion(await improveWithAi(entity, webSearch))
+        } catch (err) {
+            setAiError(err instanceof Error ? err.message : String(err))
+        } finally {
+            setImproving(false)
+        }
+    }
+
+    const handleApply = () => {
+        if (!suggestion || !onApply) return
+        onApply(suggestion)
+        setSuggestion(null)
+        setApplied(true)
+        if (appliedTimerRef.current) clearTimeout(appliedTimerRef.current)
+        appliedTimerRef.current = setTimeout(() => {
+            setApplied(false)
+        }, 5000)
+    }
+
+    return (
+        <div className="rounded-lg border border-neutral-200 bg-neutral-50 p-3">
+            <h2 className="text-sm font-medium text-neutral-800">ИИ-помощник</h2>
+            <p className="mt-0.5 text-xs text-neutral-500">
+                Нажмите «Улучшить с ИИ» или скопируйте промпт в ChatGPT/Claude, чтобы улучшить название и описание.
+            </p>
+            <textarea
+                readOnly
+                rows={8}
+                value={prompt}
+                className="mt-2 w-full resize-y rounded-lg border border-neutral-300 bg-white px-3 py-2 font-mono text-xs"
+            />
+            <label className="mt-2 flex items-center gap-2 text-sm text-neutral-700">
+                <input
+                    type="checkbox"
+                    checked={webSearch}
+                    onChange={(event) => {
+                        setWebSearch(event.target.checked)
+                    }}
+                    className="h-4 w-4 rounded border-neutral-300 text-blue-600"
+                />
+                Искать в интернете (точки интереса, проверка фактов — медленнее)
+            </label>
+            <div className="mt-2 flex gap-2">
+                {onApply && (
+                    <button
+                        type="button"
+                        onClick={() => {
+                            void handleImprove()
+                        }}
+                        disabled={improving}
+                        className="cursor-pointer rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:bg-blue-300"
+                    >
+                        {improving ? 'Улучшаю…' : 'Улучшить с ИИ'}
+                    </button>
+                )}
+                <button
+                    type="button"
+                    onClick={() => {
+                        void handleCopy()
+                    }}
+                    className="cursor-pointer rounded-lg border border-neutral-300 px-3 py-2 text-sm font-medium hover:bg-neutral-100"
+                >
+                    {copied ? 'Скопировано' : 'Скопировать промпт'}
+                </button>
+            </div>
+
+            {aiError && <div className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{aiError}</div>}
+
+            {applied && (
+                <div className="mt-2 rounded-lg bg-green-50 px-3 py-2 text-sm text-green-700">
+                    Подставлено в поля формы — проверьте и нажмите «Сохранить».
+                </div>
+            )}
+
+            {suggestion && onApply && (
+                <div className="mt-2 rounded-lg border border-blue-200 bg-blue-50 p-3">
+                    <div className="text-xs font-medium text-neutral-500">Предложение ИИ</div>
+                    <div className="mt-1 text-sm font-medium text-neutral-800">{suggestion.title}</div>
+                    <div className="mt-1 text-sm whitespace-pre-wrap text-neutral-700">{suggestion.description}</div>
+                    {suggestion.pois.length > 0 && (
+                        <div className="mt-2">
+                            <div className="text-xs font-medium text-neutral-500">Точки интереса рядом</div>
+                            <ul className="mt-1 list-disc pl-5 text-sm text-neutral-700">
+                                {suggestion.pois.map((poi) => (
+                                    <li key={poi}>{poi}</li>
+                                ))}
+                            </ul>
+                        </div>
+                    )}
+                    <div className="mt-2 flex gap-2">
+                        <button
+                            type="button"
+                            onClick={handleApply}
+                            className="cursor-pointer rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-700"
+                        >
+                            Применить
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                setSuggestion(null)
+                            }}
+                            className="cursor-pointer rounded-lg border border-neutral-300 px-3 py-2 text-sm font-medium hover:bg-neutral-100"
+                        >
+                            Отклонить
+                        </button>
+                    </div>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/src/admin/components/PointForm.test.tsx
+++ b/src/admin/components/PointForm.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { PointForm, type PointFormValue } from './PointForm'
+
+vi.mock('@/admin/components/AdminPointLocationMap', () => ({
+    AdminPointLocationMap: () => <div data-testid="map-stub" />,
+}))
+
+vi.mock('@/admin/lib/adminApi', () => ({
+    improveWithAi: vi.fn(),
+}))
+
+import { improveWithAi } from '@/admin/lib/adminApi'
+
+const INITIAL: PointFormValue = {
+    type: 'point',
+    title: 'первомайские пруды',
+    description: 'старое описание',
+    coordinates: [76.878922, 43.278067],
+    flag_is_meeting: true,
+    flag_has_socket: false,
+    flag_erlan: false,
+    flag_disabled: false,
+}
+
+describe('PointForm + ИИ-помощник', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        // jsdom не реализует scrollIntoView (используется после «Применить»)
+        Element.prototype.scrollIntoView = vi.fn()
+        vi.mocked(improveWithAi).mockResolvedValue({
+            title: 'Первомайские пруды',
+            description: 'Новое описание от ИИ.',
+            pois: [],
+        })
+    })
+
+    it('«Применить» подставляет предложение ИИ в поля названия и описания', async () => {
+        render(<PointForm initial={INITIAL} submitLabel="Сохранить" onSubmit={vi.fn()} />)
+
+        const titleInput = screen.getByDisplayValue('первомайские пруды')
+        const descriptionInput = screen.getByDisplayValue('старое описание')
+
+        fireEvent.click(screen.getByRole('button', { name: 'Улучшить с ИИ' }))
+        fireEvent.click(await screen.findByRole('button', { name: 'Применить' }))
+
+        expect((titleInput as HTMLInputElement).value).toBe('Первомайские пруды')
+        expect((descriptionInput as HTMLTextAreaElement).value).toBe('Новое описание от ИИ.')
+    })
+})

--- a/src/admin/components/PointForm.tsx
+++ b/src/admin/components/PointForm.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type
 import type { MapPointType } from '@/types'
 import type { MapPointInput } from '@/admin/lib/adminApi'
 import { AdminPointLocationMap } from '@/admin/components/AdminPointLocationMap'
+import { AiAssistPanel } from '@/admin/components/AiAssistPanel'
 import { useCoordinateHistory } from '@/admin/hooks/useCoordinateHistory'
 import { useUndoRedoHotkeys } from '@/admin/hooks/useUndoRedoHotkeys'
 import { getUndoRedoShortcuts } from '@/utils/platformShortcuts'
@@ -40,6 +41,7 @@ export function PointForm({ initial, submitLabel, onSubmit, onCancel, children }
     const [flagDisabled, setFlagDisabled] = useState(initial.flag_disabled)
     const [submitting, setSubmitting] = useState(false)
     const [error, setError] = useState<string | null>(null)
+    const titleInputRef = useRef<HTMLInputElement | null>(null)
 
     const {
         reset: resetCoordHistory,
@@ -165,6 +167,7 @@ export function PointForm({ initial, submitLabel, onSubmit, onCancel, children }
                     <div>
                         <label className="mb-1 block text-xs font-medium text-neutral-700">Название</label>
                         <input
+                            ref={titleInputRef}
                             value={title}
                             onChange={(event) => {
                                 setTitle(event.target.value)
@@ -291,6 +294,27 @@ export function PointForm({ initial, submitLabel, onSubmit, onCancel, children }
                     )}
                 </div>
                 {children}
+                <AiAssistPanel
+                    entity={{
+                        kind: 'point',
+                        pointType: type,
+                        title,
+                        description,
+                        coordinates: [
+                            parseCoordInput(lng, initial.coordinates[0]),
+                            parseCoordInput(lat, initial.coordinates[1]),
+                        ],
+                        flagIsMeeting: type === 'point' && flagIsMeeting,
+                        flagHasSocket: type === 'socket' || flagHasSocket,
+                        flagErlan,
+                    }}
+                    onApply={(suggestion) => {
+                        setTitle(suggestion.title)
+                        setDescription(suggestion.description)
+                        // Поля наверху формы, панель внизу — показать админу, что значения подставились.
+                        titleInputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                    }}
+                />
             </form>
 
             <div className="flex min-h-[280px] min-w-0 flex-col gap-2 lg:min-h-0">

--- a/src/admin/lib/adminApi/aiAssist.ts
+++ b/src/admin/lib/adminApi/aiAssist.ts
@@ -1,0 +1,32 @@
+import { db } from '@/admin/lib/adminApi/query'
+import type { AiAssistEntity } from '@/admin/utils/aiAssistPrompt'
+
+/** Предложение нейросети: улучшенные название/описание и точки интереса рядом. */
+export interface AiSuggestion {
+    title: string
+    description: string
+    pois: string[]
+}
+
+/**
+ * Вызывает edge-функцию ai-assist: строит промпт на сервере, спрашивает OpenAI
+ * и возвращает улучшенные название/описание (+ точки интереса при webSearch).
+ * `functions.invoke` сам прикладывает Authorization из сессии; функция проверяет
+ * членство в `map_admin_users`.
+ */
+export async function improveWithAi(entity: AiAssistEntity, webSearch: boolean): Promise<AiSuggestion> {
+    const { data, error } = (await db().functions.invoke('ai-assist', { body: { entity, webSearch } })) as {
+        data: unknown
+        error: { message: string } | null
+    }
+    if (error) {
+        console.error('improveWithAi:', error)
+        throw new Error(error.message)
+    }
+    const obj = data as Record<string, unknown> | null
+    if (typeof obj?.title !== 'string' || typeof obj.description !== 'string') {
+        throw new Error('Некорректный ответ ai-assist')
+    }
+    const pois = Array.isArray(obj.pois) ? obj.pois.filter((p): p is string => typeof p === 'string') : []
+    return { title: obj.title, description: obj.description, pois }
+}

--- a/src/admin/lib/adminApi/index.ts
+++ b/src/admin/lib/adminApi/index.ts
@@ -105,3 +105,5 @@ export {
 } from '@/admin/lib/adminApi/newsAnnouncements'
 
 export { getDashboardStats } from '@/admin/lib/adminApi/dashboard'
+
+export { improveWithAi, type AiSuggestion } from '@/admin/lib/adminApi/aiAssist'

--- a/src/admin/pages/RouteEditPage.tsx
+++ b/src/admin/pages/RouteEditPage.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useState, type SyntheticEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type SyntheticEvent } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { useCoordinateHistory } from '@/admin/hooks/useCoordinateHistory'
 import { useUndoRedoHotkeys } from '@/admin/hooks/useUndoRedoHotkeys'
 import { createRoute, deleteRoute, getRoute, updateRoute, type AdminMapRoute } from '@/admin/lib/adminApi'
+import { AiAssistPanel } from '@/admin/components/AiAssistPanel'
 import { ConfirmDialog } from '@/admin/components/ConfirmDialog'
 import { AdminRoutePolylineMap } from '@/admin/components/AdminRoutePolylineMap'
 import type { RouteEditorCoordinates } from '@/admin/route-editor/routeGeometry'
@@ -84,6 +85,7 @@ export function RouteEditPage({ mode }: RouteEditPageProps) {
     const routeId = mode === 'edit' && Number.isFinite(routeIdRaw) ? routeIdRaw : null
 
     const [value, setValue] = useState<FormValue | null>(mode === 'create' ? DEFAULT_VALUE : null)
+    const titleInputRef = useRef<HTMLInputElement | null>(null)
     const [error, setError] = useState<string | null>(null)
     const [submitting, setSubmitting] = useState(false)
     const [deleting, setDeleting] = useState(false)
@@ -297,6 +299,7 @@ export function RouteEditPage({ mode }: RouteEditPageProps) {
                         <div>
                             <label className="mb-1 block text-xs font-medium text-neutral-700">Название</label>
                             <input
+                                ref={titleInputRef}
                                 value={value.title}
                                 onChange={(event) => {
                                     setValue({ ...value, title: event.target.value })
@@ -399,6 +402,26 @@ export function RouteEditPage({ mode }: RouteEditPageProps) {
                                 Отмена
                             </button>
                         </div>
+
+                        <AiAssistPanel
+                            entity={{
+                                kind: 'route',
+                                title: value.title,
+                                description: value.description,
+                                startCoordinates: [value.coordinates[0][0], value.coordinates[0][1]],
+                                endCoordinates: [
+                                    value.coordinates[value.coordinates.length - 1][0],
+                                    value.coordinates[value.coordinates.length - 1][1],
+                                ],
+                                vertexCount: value.coordinates.length,
+                                flagErlan: value.flagErlan,
+                            }}
+                            onApply={(suggestion) => {
+                                setValue({ ...value, title: suggestion.title, description: suggestion.description })
+                                // Поля наверху формы, панель внизу — показать админу, что значения подставились.
+                                titleInputRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                            }}
+                        />
                     </form>
 
                     <div className="flex min-h-70 min-w-0 flex-col gap-2 lg:min-h-0">

--- a/src/admin/utils/aiAssistPrompt.test.ts
+++ b/src/admin/utils/aiAssistPrompt.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import { buildAiAssistPrompt, type AiAssistEntity } from './aiAssistPrompt'
+
+function makePoint(over: Partial<Extract<AiAssistEntity, { kind: 'point' }>> = {}): AiAssistEntity {
+    return {
+        kind: 'point',
+        pointType: 'point',
+        title: 'Роща Баума',
+        description: 'Тенистая роща, удобно собираться у входа.',
+        coordinates: [76.945, 43.238],
+        flagIsMeeting: true,
+        flagHasSocket: true,
+        flagErlan: true,
+        ...over,
+    }
+}
+
+function makeRoute(over: Partial<Extract<AiAssistEntity, { kind: 'route' }>> = {}): AiAssistEntity {
+    return {
+        kind: 'route',
+        title: 'Терренкур',
+        description: 'Вдоль речки, асфальт.',
+        startCoordinates: [76.945, 43.238],
+        endCoordinates: [76.95, 43.24],
+        vertexCount: 12,
+        flagErlan: false,
+        ...over,
+    }
+}
+
+describe('buildAiAssistPrompt', () => {
+    it('точка со всеми флагами: тип, признаки, название и описание в тексте', () => {
+        const prompt = buildAiAssistPrompt(makePoint())
+        expect(prompt).toContain('Объект: Точка')
+        expect(prompt).toContain(
+            'Признаки: Место встречи; Есть розетка; Ерландия (самые сложные горные маршруты — проезжает только Ерлан)',
+        )
+        expect(prompt).toContain('Текущее название: «Роща Баума»')
+        expect(prompt).toContain('«Тенистая роща, удобно собираться у входа.»')
+    })
+
+    it('розетка: тип «Розетка»', () => {
+        const prompt = buildAiAssistPrompt(makePoint({ pointType: 'socket', flagIsMeeting: false }))
+        expect(prompt).toContain('Объект: Розетка')
+        expect(prompt).not.toContain('Место встречи')
+    })
+
+    it('без флагов: «Признаки: нет»', () => {
+        const prompt = buildAiAssistPrompt(makePoint({ flagIsMeeting: false, flagHasSocket: false, flagErlan: false }))
+        expect(prompt).toContain('Признаки: нет')
+    })
+
+    it('пустое и пробельное описание: просьба составить с нуля', () => {
+        for (const description of ['', '   \n  ']) {
+            const prompt = buildAiAssistPrompt(makePoint({ description }))
+            expect(prompt).toContain('Описание отсутствует — составь его с нуля по контексту.')
+            expect(prompt).not.toContain('Текущее описание')
+        }
+    })
+
+    it('пустое название: «(отсутствует)»', () => {
+        const prompt = buildAiAssistPrompt(makePoint({ title: '  ' }))
+        expect(prompt).toContain('Текущее название: (отсутствует)')
+    })
+
+    it('координаты: порядок «широта, долгота», округление до 6 знаков', () => {
+        const prompt = buildAiAssistPrompt(makePoint({ coordinates: [76.9048481234, 43.2268071234] }))
+        expect(prompt).toContain('Координаты: 43.226807, 76.904848 (широта, долгота)')
+    })
+
+    it('маршрут: старт, финиш, число вершин', () => {
+        const prompt = buildAiAssistPrompt(makeRoute())
+        expect(prompt).toContain('Объект: Маршрут')
+        expect(prompt).toContain('Старт: 43.238, 76.945 (широта, долгота)')
+        expect(prompt).toContain('Финиш: 43.24, 76.95 (широта, долгота)')
+        expect(prompt).toContain('Вершин: 12')
+    })
+
+    it('маршрут с Ерландией: флаг в признаках', () => {
+        const prompt = buildAiAssistPrompt(makeRoute({ flagErlan: true }))
+        expect(prompt).toContain('Признаки: Ерландия (самые сложные горные маршруты — проезжает только Ерлан)')
+    })
+
+    it('webSearch: false — без интернет-инструкций и pois в формате ответа', () => {
+        const prompt = buildAiAssistPrompt(makePoint(), { webSearch: false })
+        expect(prompt).not.toContain('поиск в интернете')
+        expect(prompt).not.toContain('точки интереса')
+        expect(prompt).not.toContain('pois')
+        expect(prompt).toContain('{"title": "...", "description": "..."}')
+    })
+
+    it('общая рамка присутствует для обоих видов', () => {
+        for (const entity of [makePoint(), makeRoute()]) {
+            const prompt = buildAiAssistPrompt(entity)
+            expect(prompt).toContain('от 4 до 99 символов')
+            expect(prompt).toContain('не добавляй город и страну')
+            expect(prompt).toContain('не упоминай слова «Ерландия» и «Ерлан»')
+            expect(prompt).toContain(
+                '{"title": "...", "description": "...", "pois": ["Название — чем полезна", "..."]}',
+            )
+            expect(prompt).toContain('2–3 точки интереса')
+            expect(prompt).toContain('map.euc.kz')
+        }
+    })
+})

--- a/src/admin/utils/aiAssistPrompt.ts
+++ b/src/admin/utils/aiAssistPrompt.ts
@@ -1,0 +1,108 @@
+/**
+ * Билдер промпта для улучшения названия и описания объекта карты через внешнюю нейросеть.
+ *
+ * ВАЖНО: модуль намеренно самодостаточный (ноль импортов) — при добавлении edge-функции
+ * «Улучшить с ИИ» он копируется в supabase/functions/<fn>/_pure.ts (Deno не импортирует
+ * из src/). Правки синхронизировать в обеих копиях.
+ */
+
+/** Плоские данные объекта карты для промпта — без зависимостей от типов adminApi. */
+export type AiAssistEntity =
+    | {
+          kind: 'point'
+          pointType: 'point' | 'socket'
+          title: string
+          description: string
+          coordinates: [number, number] // [lng, lat]
+          flagIsMeeting: boolean
+          flagHasSocket: boolean
+          flagErlan: boolean
+      }
+    | {
+          kind: 'route'
+          title: string
+          description: string
+          startCoordinates: [number, number] // [lng, lat]
+          endCoordinates: [number, number]
+          vertexCount: number
+          flagErlan: boolean
+      }
+
+const FLAG_MEETING_LABEL = 'Место встречи'
+const FLAG_SOCKET_LABEL = 'Есть розетка'
+const FLAG_ERLAN_LABEL = 'Ерландия (самые сложные горные маршруты — проезжает только Ерлан)'
+
+/** Форматирует [lng, lat] как «широта, долгота» с округлением до 6 знаков. */
+function formatLatLng(coordinates: [number, number]): string {
+    const round = (n: number) => String(Math.round(n * 1e6) / 1e6)
+    return `${round(coordinates[1])}, ${round(coordinates[0])}`
+}
+
+function formatFlags(flags: string[]): string {
+    return flags.length > 0 ? flags.join('; ') : 'нет'
+}
+
+function buildContextLines(entity: AiAssistEntity): string[] {
+    if (entity.kind === 'point') {
+        const flags: string[] = []
+        if (entity.flagIsMeeting) flags.push(FLAG_MEETING_LABEL)
+        if (entity.flagHasSocket) flags.push(FLAG_SOCKET_LABEL)
+        if (entity.flagErlan) flags.push(FLAG_ERLAN_LABEL)
+        return [
+            `Объект: ${entity.pointType === 'socket' ? 'Розетка' : 'Точка'}`,
+            `Координаты: ${formatLatLng(entity.coordinates)} (широта, долгота)`,
+            `Признаки: ${formatFlags(flags)}`,
+        ]
+    }
+    const flags: string[] = []
+    if (entity.flagErlan) flags.push(FLAG_ERLAN_LABEL)
+    return [
+        'Объект: Маршрут',
+        `Старт: ${formatLatLng(entity.startCoordinates)} (широта, долгота)`,
+        `Финиш: ${formatLatLng(entity.endCoordinates)} (широта, долгота)`,
+        `Вершин: ${String(entity.vertexCount)}`,
+        `Признаки: ${formatFlags(flags)}`,
+    ]
+}
+
+/**
+ * Строит промпт (по-русски) для улучшения названия и описания объекта карты.
+ * При webSearch (по умолчанию) добавляет инструкции про проверку фактов в интернете
+ * и поиск точек интереса (pois); без него pois не запрашиваются.
+ */
+export function buildAiAssistPrompt(entity: AiAssistEntity, options?: { webSearch?: boolean }): string {
+    const webSearch = options?.webSearch ?? true
+    const title = entity.title.trim()
+    const description = entity.description.trim()
+
+    const lines: string[] = [
+        'Ты редактор карты map.euc.kz для райдеров моноколёс (EUC) в Алматы.',
+        'Улучши название и описание объекта карты на русском языке.',
+        '',
+        ...buildContextLines(entity),
+        '',
+        title ? `Текущее название: «${title}»` : 'Текущее название: (отсутствует)',
+        description ? `Текущее описание:\n«${description}»` : 'Описание отсутствует — составь его с нуля по контексту.',
+        '',
+        'Требования:',
+        '- Название: от 4 до 99 символов, ёмкое и конкретное, без кавычек и эмодзи; не добавляй город и страну — вся карта про Алматы.',
+        '- Описание: 1–3 коротких предложения с полезными райдеру деталями (ориентиры, покрытие, зарядка).',
+        '- Признаки выше — служебный контекст, они уже показаны на карте метками: не цитируй их, не упоминай слова «Ерландия» и «Ерлан». Их суть (сложный горный рельеф, розетка, место сбора) при желании передай своими словами.',
+        '- Исправь орфографию, пунктуацию и стиль, сохрани все факты из исходного текста.',
+        '- Не выдумывай факты, которых нет в исходных данных.',
+        ...(webSearch
+            ? [
+                  '- Если доступен поиск в интернете — используй его для проверки фактов и поиска точек интереса.',
+                  '- Найди 2–3 точки интереса рядом с объектом (кафе, зарядка, вода, виды, сервис) и верни их в списке pois,',
+                  '  каждая строкой «Название — чем полезна райдеру». Если уверенных вариантов нет — верни пустой список.',
+              ]
+            : []),
+        '- В значениях JSON — только чистый текст: без markdown, без ссылок, без сносок и упоминаний источников.',
+        '',
+        'Ответ верни строго одним JSON-объектом без пояснений и markdown:',
+        webSearch
+            ? '{"title": "...", "description": "...", "pois": ["Название — чем полезна", "..."]}'
+            : '{"title": "...", "description": "..."}',
+    ]
+    return lines.join('\n')
+}

--- a/supabase/functions/ai-assist/_pure.test.ts
+++ b/supabase/functions/ai-assist/_pure.test.ts
@@ -1,0 +1,159 @@
+import { assertEquals } from 'https://deno.land/std@0.224.0/assert/mod.ts'
+import {
+    buildAiAssistPrompt,
+    extractResponsesOutputText,
+    parseAiAssistEntity,
+    parseAiSuggestion,
+    type AiAssistEntity,
+} from './_pure.ts'
+
+const POINT: AiAssistEntity = {
+    kind: 'point',
+    pointType: 'point',
+    title: 'Роща Баума',
+    description: 'Тенистая роща.',
+    coordinates: [76.945, 43.238],
+    flagIsMeeting: true,
+    flagHasSocket: false,
+    flagErlan: false,
+}
+
+const ROUTE: AiAssistEntity = {
+    kind: 'route',
+    title: 'Терренкур',
+    description: 'Вдоль речки.',
+    startCoordinates: [76.945, 43.238],
+    endCoordinates: [76.95, 43.24],
+    vertexCount: 12,
+    flagErlan: true,
+}
+
+Deno.test('buildAiAssistPrompt: точка — тип, координаты «широта, долгота», признаки', () => {
+    const prompt = buildAiAssistPrompt(POINT)
+    assertEquals(prompt.includes('Объект: Точка'), true)
+    assertEquals(prompt.includes('Координаты: 43.238, 76.945 (широта, долгота)'), true)
+    assertEquals(prompt.includes('Признаки: Место встречи'), true)
+    assertEquals(
+        prompt.includes('{"title": "...", "description": "...", "pois": ["Название — чем полезна", "..."]}'),
+        true,
+    )
+})
+
+Deno.test('buildAiAssistPrompt: маршрут — старт/финиш/вершины, Ерландия', () => {
+    const prompt = buildAiAssistPrompt(ROUTE)
+    assertEquals(prompt.includes('Объект: Маршрут'), true)
+    assertEquals(prompt.includes('Старт: 43.238, 76.945 (широта, долгота)'), true)
+    assertEquals(prompt.includes('Вершин: 12'), true)
+    assertEquals(prompt.includes('Ерландия (самые сложные горные маршруты — проезжает только Ерлан)'), true)
+    assertEquals(prompt.includes('не упоминай слова «Ерландия» и «Ерлан»'), true)
+    assertEquals(prompt.includes('не добавляй город и страну'), true)
+})
+
+Deno.test('buildAiAssistPrompt: webSearch=false — без интернет-инструкций и pois', () => {
+    const prompt = buildAiAssistPrompt(POINT, { webSearch: false })
+    assertEquals(prompt.includes('поиск в интернете'), false)
+    assertEquals(prompt.includes('pois'), false)
+    assertEquals(prompt.includes('{"title": "...", "description": "..."}'), true)
+})
+
+Deno.test('parseAiAssistEntity: валидная точка и маршрут проходят', () => {
+    assertEquals(parseAiAssistEntity(POINT), POINT)
+    assertEquals(parseAiAssistEntity(ROUTE), ROUTE)
+})
+
+Deno.test('parseAiAssistEntity: мусор отклоняется', () => {
+    assertEquals(parseAiAssistEntity(null), null)
+    assertEquals(parseAiAssistEntity('строка'), null)
+    assertEquals(parseAiAssistEntity({}), null)
+    assertEquals(parseAiAssistEntity({ ...POINT, kind: 'event' }), null)
+    assertEquals(parseAiAssistEntity({ ...POINT, coordinates: [76.945] }), null)
+    assertEquals(parseAiAssistEntity({ ...POINT, coordinates: ['76.9', '43.2'] }), null)
+    assertEquals(parseAiAssistEntity({ ...POINT, flagIsMeeting: 'да' }), null)
+    assertEquals(parseAiAssistEntity({ ...ROUTE, vertexCount: 1 }), null)
+    assertEquals(parseAiAssistEntity({ ...ROUTE, vertexCount: 2.5 }), null)
+})
+
+Deno.test('parseAiSuggestion: чистый JSON проходит, pois опциональны', () => {
+    assertEquals(parseAiSuggestion('{"title": "Роща Баума", "description": "Тенистая роща у входа."}'), {
+        title: 'Роща Баума',
+        description: 'Тенистая роща у входа.',
+        pois: [],
+    })
+})
+
+Deno.test('parseAiSuggestion: markdown-ограждения срезаются', () => {
+    assertEquals(parseAiSuggestion('```json\n{"title": "Роща Баума", "description": "Роща."}\n```'), {
+        title: 'Роща Баума',
+        description: 'Роща.',
+        pois: [],
+    })
+})
+
+Deno.test('parseAiSuggestion: pois — до 3 непустых строк, мусор отбрасывается', () => {
+    const raw = JSON.stringify({
+        title: 'Роща Баума',
+        description: 'Роща.',
+        pois: ['Кафе — кофе', '  ', 42, 'Родник — вода', 'Сервис — ремонт', 'Лишняя — четвёртая'],
+    })
+    assertEquals(parseAiSuggestion(raw)?.pois, ['Кафе — кофе', 'Родник — вода', 'Сервис — ремонт'])
+    assertEquals(parseAiSuggestion('{"title": "Роща Баума", "description": "Роща.", "pois": "не массив"}')?.pois, [])
+})
+
+Deno.test('extractResponsesOutputText: берёт output_text из последнего message', () => {
+    const payload = {
+        output: [
+            { type: 'web_search_call', id: 'ws_1' },
+            {
+                type: 'message',
+                content: [
+                    { type: 'output_text', text: '{"title": "А", ' },
+                    { type: 'output_text', text: '"description": "Б"}' },
+                ],
+            },
+        ],
+    }
+    assertEquals(extractResponsesOutputText(payload), '{"title": "А", "description": "Б"}')
+    assertEquals(extractResponsesOutputText({ output: [] }), null)
+    assertEquals(extractResponsesOutputText(null), null)
+    assertEquals(extractResponsesOutputText({ output: [{ type: 'message', content: [] }] }), null)
+})
+
+Deno.test('parseAiSuggestion: название триммится и обрезается до 99 символов', () => {
+    const long = 'а'.repeat(150)
+    const parsed = parseAiSuggestion(JSON.stringify({ title: `  ${long}  `, description: 'Ок.' }))
+    assertEquals(parsed?.title.length, 99)
+})
+
+Deno.test('parseAiSuggestion: сноски web-поиска и markdown-ссылки вычищаются', () => {
+    const raw = JSON.stringify({
+        title: 'Визит-центр Аюсай ([wiki](https://ru.wikipedia.org/wiki/Аюсай?utm_source=openai))',
+        description:
+            'Розетка на здании туалета справа от входа. ([tengrinews.kz](https://tengrinews.kz/guide-map_object/40/amp/?utm_source=openai))',
+        pois: [
+            'Tary — этно-кофейня при визит-центре. ([sxodim.com](https://sxodim.com/almaty/place/kofeynya-tary?utm_source=openai))',
+            'Водопад Аюсай — [живописная точка](https://naturalist.travel/x) для отдыха (https://example.com/page)',
+        ],
+    })
+    assertEquals(parseAiSuggestion(raw), {
+        title: 'Визит-центр Аюсай',
+        description: 'Розетка на здании туалета справа от входа.',
+        pois: ['Tary — этно-кофейня при визит-центре.', 'Водопад Аюсай — живописная точка для отдыха'],
+    })
+})
+
+Deno.test('parseAiSuggestion: сноска с несколькими источниками удаляется целиком', () => {
+    const raw = JSON.stringify({
+        title: 'Роща Баума',
+        description: 'Тенистая роща. ([a](https://a.kz/1), [b](https://b.kz/2))',
+    })
+    assertEquals(parseAiSuggestion(raw)?.description, 'Тенистая роща.')
+})
+
+Deno.test('parseAiSuggestion: невалидные ответы отклоняются', () => {
+    assertEquals(parseAiSuggestion(undefined), null)
+    assertEquals(parseAiSuggestion('не json'), null)
+    assertEquals(parseAiSuggestion('{"title": "аб", "description": "Ок."}'), null)
+    assertEquals(parseAiSuggestion('{"title": "Роща Баума", "description": ""}'), null)
+    assertEquals(parseAiSuggestion('{"title": "Роща Баума"}'), null)
+    assertEquals(parseAiSuggestion('[1, 2]'), null)
+})

--- a/supabase/functions/ai-assist/_pure.ts
+++ b/supabase/functions/ai-assist/_pure.ts
@@ -1,0 +1,238 @@
+/**
+ * Чистые функции edge-функции ai-assist: билдер промпта, валидация входа и ответа OpenAI.
+ *
+ * ВАЖНО: тип AiAssistEntity и buildAiAssistPrompt — копия src/admin/utils/aiAssistPrompt.ts
+ * (Deno не импортирует из src/). Правки синхронизировать в обеих копиях.
+ */
+
+/** Плоские данные объекта карты для промпта — без зависимостей от типов adminApi. */
+export type AiAssistEntity =
+    | {
+          kind: 'point'
+          pointType: 'point' | 'socket'
+          title: string
+          description: string
+          coordinates: [number, number] // [lng, lat]
+          flagIsMeeting: boolean
+          flagHasSocket: boolean
+          flagErlan: boolean
+      }
+    | {
+          kind: 'route'
+          title: string
+          description: string
+          startCoordinates: [number, number] // [lng, lat]
+          endCoordinates: [number, number]
+          vertexCount: number
+          flagErlan: boolean
+      }
+
+const FLAG_MEETING_LABEL = 'Место встречи'
+const FLAG_SOCKET_LABEL = 'Есть розетка'
+const FLAG_ERLAN_LABEL = 'Ерландия (самые сложные горные маршруты — проезжает только Ерлан)'
+
+/** Форматирует [lng, lat] как «широта, долгота» с округлением до 6 знаков. */
+function formatLatLng(coordinates: [number, number]): string {
+    const round = (n: number) => String(Math.round(n * 1e6) / 1e6)
+    return `${round(coordinates[1])}, ${round(coordinates[0])}`
+}
+
+function formatFlags(flags: string[]): string {
+    return flags.length > 0 ? flags.join('; ') : 'нет'
+}
+
+function buildContextLines(entity: AiAssistEntity): string[] {
+    if (entity.kind === 'point') {
+        const flags: string[] = []
+        if (entity.flagIsMeeting) flags.push(FLAG_MEETING_LABEL)
+        if (entity.flagHasSocket) flags.push(FLAG_SOCKET_LABEL)
+        if (entity.flagErlan) flags.push(FLAG_ERLAN_LABEL)
+        return [
+            `Объект: ${entity.pointType === 'socket' ? 'Розетка' : 'Точка'}`,
+            `Координаты: ${formatLatLng(entity.coordinates)} (широта, долгота)`,
+            `Признаки: ${formatFlags(flags)}`,
+        ]
+    }
+    const flags: string[] = []
+    if (entity.flagErlan) flags.push(FLAG_ERLAN_LABEL)
+    return [
+        'Объект: Маршрут',
+        `Старт: ${formatLatLng(entity.startCoordinates)} (широта, долгота)`,
+        `Финиш: ${formatLatLng(entity.endCoordinates)} (широта, долгота)`,
+        `Вершин: ${String(entity.vertexCount)}`,
+        `Признаки: ${formatFlags(flags)}`,
+    ]
+}
+
+/**
+ * Строит промпт (по-русски) для улучшения названия и описания объекта карты.
+ * При webSearch (по умолчанию) добавляет инструкции про проверку фактов в интернете
+ * и поиск точек интереса (pois); без него pois не запрашиваются.
+ */
+export function buildAiAssistPrompt(entity: AiAssistEntity, options?: { webSearch?: boolean }): string {
+    const webSearch = options?.webSearch ?? true
+    const title = entity.title.trim()
+    const description = entity.description.trim()
+
+    const lines: string[] = [
+        'Ты редактор карты map.euc.kz для райдеров моноколёс (EUC) в Алматы.',
+        'Улучши название и описание объекта карты на русском языке.',
+        '',
+        ...buildContextLines(entity),
+        '',
+        title ? `Текущее название: «${title}»` : 'Текущее название: (отсутствует)',
+        description ? `Текущее описание:\n«${description}»` : 'Описание отсутствует — составь его с нуля по контексту.',
+        '',
+        'Требования:',
+        '- Название: от 4 до 99 символов, ёмкое и конкретное, без кавычек и эмодзи; не добавляй город и страну — вся карта про Алматы.',
+        '- Описание: 1–3 коротких предложения с полезными райдеру деталями (ориентиры, покрытие, зарядка).',
+        '- Признаки выше — служебный контекст, они уже показаны на карте метками: не цитируй их, не упоминай слова «Ерландия» и «Ерлан». Их суть (сложный горный рельеф, розетка, место сбора) при желании передай своими словами.',
+        '- Исправь орфографию, пунктуацию и стиль, сохрани все факты из исходного текста.',
+        '- Не выдумывай факты, которых нет в исходных данных.',
+        ...(webSearch
+            ? [
+                  '- Если доступен поиск в интернете — используй его для проверки фактов и поиска точек интереса.',
+                  '- Найди 2–3 точки интереса рядом с объектом (кафе, зарядка, вода, виды, сервис) и верни их в списке pois,',
+                  '  каждая строкой «Название — чем полезна райдеру». Если уверенных вариантов нет — верни пустой список.',
+              ]
+            : []),
+        '- В значениях JSON — только чистый текст: без markdown, без ссылок, без сносок и упоминаний источников.',
+        '',
+        'Ответ верни строго одним JSON-объектом без пояснений и markdown:',
+        webSearch
+            ? '{"title": "...", "description": "...", "pois": ["Название — чем полезна", "..."]}'
+            : '{"title": "...", "description": "..."}',
+    ]
+    return lines.join('\n')
+}
+
+function isLngLat(raw: unknown): raw is [number, number] {
+    return (
+        Array.isArray(raw) &&
+        raw.length === 2 &&
+        typeof raw[0] === 'number' &&
+        Number.isFinite(raw[0]) &&
+        typeof raw[1] === 'number' &&
+        Number.isFinite(raw[1])
+    )
+}
+
+/** Валидирует тело запроса и возвращает типизированный AiAssistEntity либо null. */
+export function parseAiAssistEntity(raw: unknown): AiAssistEntity | null {
+    if (typeof raw !== 'object' || raw === null) return null
+    const obj = raw as Record<string, unknown>
+    if (typeof obj.title !== 'string' || typeof obj.description !== 'string') return null
+    if (typeof obj.flagErlan !== 'boolean') return null
+
+    if (obj.kind === 'point') {
+        if (obj.pointType !== 'point' && obj.pointType !== 'socket') return null
+        if (!isLngLat(obj.coordinates)) return null
+        if (typeof obj.flagIsMeeting !== 'boolean' || typeof obj.flagHasSocket !== 'boolean') return null
+        return {
+            kind: 'point',
+            pointType: obj.pointType,
+            title: obj.title,
+            description: obj.description,
+            coordinates: obj.coordinates,
+            flagIsMeeting: obj.flagIsMeeting,
+            flagHasSocket: obj.flagHasSocket,
+            flagErlan: obj.flagErlan,
+        }
+    }
+
+    if (obj.kind === 'route') {
+        if (!isLngLat(obj.startCoordinates) || !isLngLat(obj.endCoordinates)) return null
+        if (typeof obj.vertexCount !== 'number' || !Number.isInteger(obj.vertexCount) || obj.vertexCount < 2)
+            return null
+        return {
+            kind: 'route',
+            title: obj.title,
+            description: obj.description,
+            startCoordinates: obj.startCoordinates,
+            endCoordinates: obj.endCoordinates,
+            vertexCount: obj.vertexCount,
+            flagErlan: obj.flagErlan,
+        }
+    }
+
+    return null
+}
+
+/** Предложение нейросети: улучшенные название/описание и точки интереса рядом. */
+export interface AiSuggestion {
+    title: string
+    description: string
+    pois: string[]
+}
+
+/**
+ * Вычищает из текста сноски-цитаты web-поиска OpenAI и markdown-ссылки:
+ * «([site](url))», «([a](u), [b](v))» удаляются целиком, «[текст](url)» → «текст»,
+ * голые URL в скобках удаляются. Модель игнорирует запрет ссылок в промпте.
+ */
+function stripInlineLinks(text: string): string {
+    return text
+        .replace(/\s*\((?:\[[^\]]*\]\([^()]*\)(?:,\s*)?)+\)/g, '')
+        .replace(/\[([^\]]*)\]\([^()]*\)/g, '$1')
+        .replace(/\s*\(https?:\/\/[^)]*\)/g, '')
+        .replace(/[ \t]{2,}/g, ' ')
+        .trim()
+}
+
+/**
+ * Парсит ответ модели: срезает возможные markdown-ограждения, валидирует JSON
+ * `{title, description, pois?}`, вычищает ссылки/сноски из значений. Название
+ * обрезается до 99 символов; короче 4 — ошибка. pois — до 3 непустых строк,
+ * при мусоре — пустой список.
+ */
+export function parseAiSuggestion(raw: unknown): AiSuggestion | null {
+    if (typeof raw !== 'string') return null
+    const cleaned = raw
+        .trim()
+        .replace(/^```(?:json)?\s*/i, '')
+        .replace(/\s*```$/, '')
+
+    let parsed: unknown
+    try {
+        parsed = JSON.parse(cleaned)
+    } catch {
+        return null
+    }
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const obj = parsed as Record<string, unknown>
+    if (typeof obj.title !== 'string' || typeof obj.description !== 'string') return null
+
+    const title = stripInlineLinks(obj.title).slice(0, 99)
+    const description = stripInlineLinks(obj.description)
+    if (title.length < 4 || !description) return null
+
+    const pois = Array.isArray(obj.pois)
+        ? obj.pois
+              .filter((p): p is string => typeof p === 'string')
+              .map(stripInlineLinks)
+              .filter(Boolean)
+              .slice(0, 3)
+        : []
+    return { title, description, pois }
+}
+
+/**
+ * Извлекает текст ответа из payload OpenAI Responses API: конкатенация
+ * output_text-фрагментов последнего message-элемента output.
+ */
+export function extractResponsesOutputText(payload: unknown): string | null {
+    if (typeof payload !== 'object' || payload === null) return null
+    const output = (payload as Record<string, unknown>).output
+    if (!Array.isArray(output)) return null
+
+    for (let i = output.length - 1; i >= 0; i--) {
+        const item = output[i] as Record<string, unknown> | null
+        if (item?.type !== 'message' || !Array.isArray(item.content)) continue
+        const text = (item.content as Array<Record<string, unknown>>)
+            .filter((part) => part.type === 'output_text' && typeof part.text === 'string')
+            .map((part) => part.text as string)
+            .join('')
+        if (text) return text
+    }
+    return null
+}

--- a/supabase/functions/ai-assist/index.ts
+++ b/supabase/functions/ai-assist/index.ts
@@ -1,0 +1,116 @@
+import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { buildAiAssistPrompt, extractResponsesOutputText, parseAiAssistEntity, parseAiSuggestion } from './_pure.ts'
+
+/** CORS-заголовки: функция вызывается из браузера админки через functions.invoke. */
+const CORS_HEADERS: Record<string, string> = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+}
+
+function jsonWithCors(body: unknown, status: number): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'content-type': 'application/json', ...CORS_HEADERS },
+    })
+}
+
+/**
+ * Проверяет, что запрос исходит от администратора (Authorization: Bearer <jwt>).
+ * Возвращает true, если user.id присутствует в map_admin_users.
+ */
+async function isAdminRequest(supabase: SupabaseClient, req: Request): Promise<boolean> {
+    const authHeader = req.headers.get('Authorization')
+    const jwt = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null
+    if (!jwt) return false
+    const { data, error } = await supabase.auth.getUser(jwt)
+    if (error || !data.user) return false
+    const { data: adminRow } = await supabase
+        .from('map_admin_users')
+        .select('user_id')
+        .eq('user_id', data.user.id)
+        .maybeSingle<{ user_id: string }>()
+    return Boolean(adminRow)
+}
+
+const supabaseUrl = Deno.env.get('SUPABASE_URL')
+const supabaseServiceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+if (!supabaseUrl || !supabaseServiceRoleKey) {
+    throw new Error('Отсутствуют SUPABASE_URL или SUPABASE_SERVICE_ROLE_KEY')
+}
+
+const supabase = createClient(supabaseUrl, supabaseServiceRoleKey)
+
+Deno.serve(async (req) => {
+    if (req.method === 'OPTIONS') {
+        return new Response('ok', { status: 200, headers: CORS_HEADERS })
+    }
+    if (req.method !== 'POST') return jsonWithCors({ error: 'method_not_allowed' }, 405)
+
+    if (!(await isAdminRequest(supabase, req))) return jsonWithCors({ error: 'unauthorized' }, 401)
+
+    const apiKey = Deno.env.get('OPENAI_API_KEY')
+    if (!apiKey) {
+        console.error('[ai-assist] OPENAI_API_KEY не задан')
+        return jsonWithCors({ error: 'no_api_key' }, 500)
+    }
+
+    let body: Record<string, unknown>
+    try {
+        body = (await req.json()) as Record<string, unknown>
+    } catch {
+        return jsonWithCors({ error: 'bad_request' }, 400)
+    }
+
+    const entity = parseAiAssistEntity(body.entity)
+    if (!entity) return jsonWithCors({ error: 'invalid_input' }, 400)
+
+    // Флаг web-поиска: по умолчанию включён, выключается чекбоксом в админке.
+    const webSearch = body.webSearch !== false
+    const model = Deno.env.get('OPENAI_MODEL') ?? 'gpt-5-mini'
+    const prompt = buildAiAssistPrompt(entity, { webSearch })
+
+    // Responses API; с web_search модель проверяет факты и ищет точки интереса
+    // в интернете (медленнее). JSON-формат не форсируем (конфликтует с поиском) —
+    // parseAiSuggestion устойчив к markdown-ограждениям.
+    let openaiResponse: Response
+    try {
+        openaiResponse = await fetch('https://api.openai.com/v1/responses', {
+            method: 'POST',
+            headers: {
+                'content-type': 'application/json',
+                authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({
+                model,
+                input: prompt,
+                ...(webSearch ? { tools: [{ type: 'web_search' }] } : {}),
+            }),
+        })
+    } catch (error) {
+        console.error('[ai-assist] Сетевая ошибка запроса к OpenAI', error)
+        return jsonWithCors({ error: 'openai_failed' }, 502)
+    }
+
+    if (!openaiResponse.ok) {
+        console.error('[ai-assist] OpenAI ответил ошибкой', {
+            status: openaiResponse.status,
+            body: (await openaiResponse.text()).slice(0, 500),
+        })
+        return jsonWithCors({ error: 'openai_failed' }, 502)
+    }
+
+    const payload = (await openaiResponse.json()) as unknown
+    const outputText = extractResponsesOutputText(payload)
+    const suggestion = parseAiSuggestion(outputText)
+    if (!suggestion) {
+        console.error('[ai-assist] Не удалось распарсить ответ модели', {
+            content: String(outputText).slice(0, 500),
+        })
+        return jsonWithCors({ error: 'bad_ai_response' }, 502)
+    }
+
+    console.info('[ai-assist] Успех', { kind: entity.kind, model, webSearch })
+    return jsonWithCors(suggestion, 200)
+})


### PR DESCRIPTION
## Summary
- Панель «ИИ-помощник» внизу форм редактирования точки (`PointForm`) и маршрута (`RouteEditPage`): автособранный read-only промпт из живых значений полей + контекст (тип, координаты, признаки), кнопка «Скопировать промпт» для ручной вставки в ChatGPT/Claude.
- Кнопка «Улучшить с ИИ» → новая edge-функция `ai-assist` (вторая в проекте): авторизация JWT-админа + `map_admin_users`, OpenAI Responses API, модель `gpt-5-mini` (переопределяется секретом `OPENAI_MODEL`).
- Чекбокс «Искать в интернете»: с ним — инструмент `web_search` (проверка фактов + 2–3 точки интереса рядом, медленнее), без него — быстрый вызов без POI.
- Ответ модели валидируется и санируется (`parseAiSuggestion`): срез markdown-ограждений, вычистка сносок-цитат web-поиска `([site](url))`, title ≤ 99 символов, pois ≤ 3.
- «Применить» подставляет title/description в форму, скроллит к полю «Название» и показывает подсказку «нажмите Сохранить».
- Промпт-билдер — чистая функция без импортов в `src/admin/utils/aiAssistPrompt.ts`, её копия в `supabase/functions/ai-assist/_pure.ts` (Deno не импортирует из src/); правки синхронизировать.
- Секреты edge-функций заливаются из `.env.local`: `npm run secrets:sync` (`scripts/set-supabase-secrets.sh`). CI деплоит `ai-assist` отдельной строкой в deploy.yml.

## Test plan
- [x] `npm run test` — 539 unit-тестов (новые: aiAssistPrompt, AiAssistPanel, PointForm apply-flow)
- [x] `npm run test:functions` — 75 deno-тестов (валидация входа, парсер ответа, санитизация ссылок)
- [x] `npm run build`, lint, format, e2e — pre-commit прошёл целиком
- [x] Живой прогон на test.euc.kz: предложение с POI, применение в форму, санитизация сносок

🤖 Generated with [Claude Code](https://claude.com/claude-code)