### PR TITLE
feat(bot): эфемерные сообщения — RSVP-подтверждение и карточка live-геопозиции

### DIFF
--- a/docs/telegram-bot.md
+++ b/docs/telegram-bot.md
@@ -41,18 +41,19 @@ JWT администратора проверяется по наличию в `
 
 ## Webhook: что обрабатывает
 
-1. **Live-геопозиции** — `message.location` с `live_period > 0` (одиночные «поделиться местом» пропускаются): INSERT в `telegram_locations` (идемпотентно по `telegram_update_id`), upsert `telegram_profiles`, при наличии токена — кэширование аватара.
+1. **Live-геопозиции** — `message.location` с `live_period > 0` (одиночные «поделиться местом» пропускаются): INSERT в `telegram_locations` (идемпотентно по `telegram_update_id`), upsert `telegram_profiles`, при наличии токена — кэширование аватара. На **старте** трансляции в группе автору шлётся эфемерный онбординг (см. «Эфемерные сообщения»).
 2. **Inline queries** (`@бот <запрос>` в любом чате) — поиск по title в `map_points`/`map_routes`, до 50 результатов, приоритет: места встреч → точки → маршруты; ссылки с UTM; `cache_time=60` (новые точки появляются в inline не мгновенно).
 3. **Callback queries** — кнопка «Участвую», `callback_data = rsvp:<event_date_uuid>` (см. ниже).
 4. **Команды** — `/start`, `/help` в личке.
 
 ## RSVP «Участвую»
 
-1. Валидация UUID; отменённая дата (`cancelled = true`) отклоняется.
+1. Валидация UUID; отменённая дата (`cancelled = true`) отклоняется. Дата подгружается вместе с событием (`starts_at`, `map_events`) — для эфемерной карточки.
 2. `ensureTelegramProfile` — upsert профиля **без** аватара (окно ответа callback узкое; аватар добьёт backfill).
 3. Toggle в `map_event_participants`: есть строка → DELETE, нет → INSERT (конфликт 23505 = идемпотентный успех).
-4. Пересчёт счётчика и `editMessageReplyMarkup` во **всех** живых анонсах этой даты во всех чатах (ошибки отдельных чатов не блокируют).
-5. `answerCallbackQuery` — toast пользователю.
+4. `answerCallbackQuery` — короткий toast пользователю.
+5. Эфемерная карточка-подтверждение в том же чате (см. «Эфемерные сообщения») — best-effort, только если событие подгрузилось и есть `chat_id`.
+6. Пересчёт счётчика и `editMessageReplyMarkup` во **всех** живых анонсах этой даты во всех чатах (ошибки отдельных чатов не блокируют).
 
 ## Анонсы
 
@@ -87,6 +88,28 @@ curl -X POST "https://api.telegram.org/bot<bot_token>/setWebhook" \
 ```
 
 Локально: `supabase functions serve telegram-location-bot` (для реального webhook нужен туннель ngrok/cloudflared).
+
+## Эфемерные сообщения (ephemeral)
+
+**Что это.** Бот отправляет **приватный ответ прямо внутри группового чата, видимый только одному пользователю** (и боту) — не засоряя общую ленту. Решает дилемму «спам в общий чат ↔ личка (требует Start)»: приватный ответ в контексте того же чата, без обоих минусов.
+
+**API** (сверять при расширении с [core.telegram.org/bots/api](https://core.telegram.org/bots/api) — фича свежая):
+
+- Отправка — существующие методы (`sendMessage`, `sendPhoto`…) + новый параметр `receiver_user_id` (кому показать; `chat_id` остаётся обязательным). Альтернатива для ответа на нажатие кнопки — `callback_query_id`.
+- `Message` получает поля `receiver_user` и `ephemeral_message_id` (id эфемерного сообщения внутри чата) — добавлены в тип `TelegramMessage` (`_pure.ts`).
+- Правка/удаление — отдельные методы `editEphemeralMessage*` / `deleteEphemeralMessage` (пока не используем — шлём свежую эфемерку на каждое событие).
+
+**Общий примитив** — `sendEphemeralMessage(chatId, receiverUserId, text, botToken)` в `_handlers.ts`: `sendMessage` + `receiver_user_id`, `parse_mode=HTML`. **Best-effort**: ошибка (в т.ч. если фича ещё недоступна боту) только логируется и **не влияет** на основной поток (запись RSVP/геопозиции). Возвращает `ephemeral_message_id` (для будущей правки) либо `null`.
+
+**Внедрено:**
+
+1. **RSVP-подтверждение** (`handleCallbackQuery`) — поверх короткого `answerCallbackQuery`-тоста шлём приватную карточку: при записи — «Ты в списке участников» + шапка события (тип · название · дата) + deep-link `/events/:id`; при выходе — «Ты больше не участвуешь» + шапка. Текст строит `buildRsvpEphemeralText` (`_pure.ts`), адресат — `receiver_user_id = cb.from.id` в `cb.message.chat.id`. Шлётся только если событие подгрузилось и `chat_id` известен.
+2. **Онбординг live-геопозиции** (`handleLocationUpdate`) — при **старте** трансляции (update как `message`, а не `edited_message`; флаг `isLiveStart` из `index.ts`) в **группе** приватно показываем автору карточку: он на карте (deep-link `/m/telegramuser/<id>`), сколько ещё райдеров онлайн и кто ближайший из них. В личке не шлём (эфемерка — про группы). Данные собирает `gatherLiveLocationStats` (последняя геопозиция каждого юзера в окне `ACTIVE_RIDER_WINDOW_MINUTES`, ближайший — `selectNearestRider` по `haversineMeters`; если он ближе `RIDER_AT_POINT_THRESHOLD_METERS` к любой точке `map_points` — показываем её как ориентир). Текст — `buildLiveLocationEphemeralText`; при 0 других райдеров — «катаешь один».
+
+**Потенциал (ещё не внедрено):**
+
+- **Приватная выдача по команде в группе** — `/спот`, `/розетки рядом`, `/маршрут N`, `/кто онлайн`: ответ виден только спросившему; при ephemeral-команде скрыт и сам вопрос.
+- **Персональные ответы на валидацию** — объяснить только автору, что нужна именно _live_-геопозиция, а не статичная (сейчас такой update молча пропускается).
 
 ## Инварианты
 

--- a/supabase/functions/telegram-location-bot/_handlers.test.ts
+++ b/supabase/functions/telegram-location-bot/_handlers.test.ts
@@ -12,9 +12,10 @@ import {
     handleAnnounceNews,
     handleEditNews,
     handleDeleteNews,
+    handleLocationUpdate,
     isAdminRequest,
 } from './_handlers.ts'
-import type { TelegramCallbackQuery } from './_pure.ts'
+import type { TelegramCallbackQuery, TelegramMessage } from './_pure.ts'
 
 // ───────────────────────────── fetch-мок для Telegram API ─────────────────────────────
 
@@ -133,6 +134,10 @@ function makeFakeSupabase(
             },
             is(col: string, val: unknown) {
                 state.filters.push({ kind: 'is', col, val })
+                return builder
+            },
+            gte(col: string, val: unknown) {
+                state.filters.push({ kind: 'gte', col, val })
                 return builder
             },
             order() {
@@ -402,6 +407,228 @@ Deno.test('handleCallbackQuery: уже участвует → delete + тост 
         )
         const answer = calls.find((c) => methodOf(c.url) === 'answerCallbackQuery')!
         assertEquals((answer.body as { text: string }).text, 'Вы больше не участвуете')
+    } finally {
+        restore()
+    }
+})
+
+// ───────────────────────────── handleCallbackQuery (эфемерное подтверждение) ─────────────────────────────
+
+/** Handler'ы даты с присоединённым событием (нужно для эфемерной карточки). */
+function rsvpDateWithEvent(): TableHandler {
+    return () => ({
+        data: {
+            id: VALID_UUID,
+            cancelled: false,
+            event_id: 7,
+            starts_at: '2026-07-14T14:00:00Z',
+            map_events: { id: 7, type: 'group_ride', title: 'Вечерняя', location_text: null },
+        },
+        error: null,
+    })
+}
+
+Deno.test('handleCallbackQuery: новый участник + известное событие → эфемерка receiver_user_id', async () => {
+    const { client } = makeFakeSupabase({
+        map_event_dates: rsvpDateWithEvent(),
+        telegram_profiles: () => ({ data: null, error: null }),
+        map_event_participants: (op) => {
+            if (op === 'select') return { data: null, error: null }
+            if (op === 'insert') return { data: null, error: null }
+            return { count: 1, error: null }
+        },
+        telegram_outbound_messages: () => ({ data: [], error: null }),
+    })
+    const { calls, restore } = installFetchMock(() => tgOk())
+    try {
+        await handleCallbackQuery(client, makeCb(`rsvp:${VALID_UUID}`), 'TOKEN', 'https://map.euc.kz')
+        const ephemeral = calls.find(
+            (c) => methodOf(c.url) === 'sendMessage' && (c.body as { receiver_user_id?: number }).receiver_user_id,
+        )!
+        assertEquals((ephemeral.body as { receiver_user_id: number }).receiver_user_id, 100)
+        assertEquals((ephemeral.body as { chat_id: number }).chat_id, -200)
+        assertEquals((ephemeral.body as { text: string }).text.startsWith('Ты в списке участников! 🛞'), true)
+    } finally {
+        restore()
+    }
+})
+
+Deno.test('handleCallbackQuery: выход из участия + событие → эфемерка «больше не участвуешь»', async () => {
+    const { client } = makeFakeSupabase({
+        map_event_dates: rsvpDateWithEvent(),
+        telegram_profiles: () => ({ data: null, error: null }),
+        map_event_participants: (op) => {
+            if (op === 'select') return { data: { id: 'part-1' }, error: null }
+            return { count: 0, error: null }
+        },
+        telegram_outbound_messages: () => ({ data: [], error: null }),
+    })
+    const { calls, restore } = installFetchMock(() => tgOk())
+    try {
+        await handleCallbackQuery(client, makeCb(`rsvp:${VALID_UUID}`), 'TOKEN', 'https://map.euc.kz')
+        const ephemeral = calls.find(
+            (c) => methodOf(c.url) === 'sendMessage' && (c.body as { receiver_user_id?: number }).receiver_user_id,
+        )!
+        assertEquals((ephemeral.body as { text: string }).text.startsWith('Ты больше не участвуешь.'), true)
+    } finally {
+        restore()
+    }
+})
+
+Deno.test('handleCallbackQuery: событие не подгрузилось (map_events=null) → эфемерку не шлём', async () => {
+    const { client } = makeFakeSupabase({
+        map_event_dates: () => ({
+            data: {
+                id: VALID_UUID,
+                cancelled: false,
+                event_id: 7,
+                starts_at: '2026-07-14T14:00:00Z',
+                map_events: null,
+            },
+            error: null,
+        }),
+        telegram_profiles: () => ({ data: null, error: null }),
+        map_event_participants: (op) => {
+            if (op === 'select') return { data: null, error: null }
+            if (op === 'insert') return { data: null, error: null }
+            return { count: 1, error: null }
+        },
+        telegram_outbound_messages: () => ({ data: [], error: null }),
+    })
+    const { calls, restore } = installFetchMock(() => tgOk())
+    try {
+        await handleCallbackQuery(client, makeCb(`rsvp:${VALID_UUID}`), 'TOKEN', 'https://map.euc.kz')
+        const ephemeral = calls.find(
+            (c) => methodOf(c.url) === 'sendMessage' && (c.body as { receiver_user_id?: number }).receiver_user_id,
+        )
+        assertEquals(ephemeral, undefined)
+    } finally {
+        restore()
+    }
+})
+
+// ───────────────────────────── handleLocationUpdate (эфемерный онбординг) ─────────────────────────────
+
+/** Live-геолокация в чате; профиль уже есть (safe avatar) — без запросов аватара/апдейта профиля. */
+function locationMessage(opts: { chatType?: string; live_period?: number } = {}): TelegramMessage {
+    return {
+        message_id: 10,
+        chat: { id: -500, type: opts.chatType ?? 'supergroup' },
+        from: { id: 777, username: 'rider', first_name: 'R' },
+        location: { longitude: 76.9, latitude: 43.2, live_period: opts.live_period ?? 900 },
+    }
+}
+
+/**
+ * Supabase-фейк для handleLocationUpdate: существующий профиль совпадает → без upsert/аватара.
+ * telegram_locations: upsert (сохранение) → ok; select (сбор статистики) → переданные строки.
+ * map_points → переданные точки-ориентиры.
+ */
+function locationSupabase(
+    opts: {
+        otherRiders?: Array<{ telegram_user_id: number; username: string | null; longitude: number; latitude: number }>
+        points?: Array<{ title: string; coordinates: number[] }>
+    } = {},
+) {
+    return makeFakeSupabase({
+        telegram_profiles: () => ({
+            data: {
+                telegram_user_id: 777,
+                username: 'rider',
+                first_name: 'R',
+                last_name: null,
+                avatar_url: 'https://cdn/telegram-avatars/777/avatar.jpg',
+            },
+            error: null,
+        }),
+        telegram_locations: (op) =>
+            op === 'select'
+                ? {
+                      data: (opts.otherRiders ?? []).map((r) => ({ ...r, first_name: null })),
+                      error: null,
+                  }
+                : { error: null },
+        map_points: () => ({ data: opts.points ?? [], error: null }),
+    })
+}
+
+Deno.test('handleLocationUpdate: старт live в группе → эфемерная карточка со статистикой', async () => {
+    const { client } = locationSupabase({
+        otherRiders: [
+            { telegram_user_id: 111, username: 'far', longitude: 76.95, latitude: 43.25 },
+            { telegram_user_id: 222, username: 'vanton', longitude: 76.9013, latitude: 43.2 },
+        ],
+        points: [{ title: 'КБТУ', coordinates: [76.9012, 43.2] }],
+    })
+    const { calls, restore } = installFetchMock(() => tgOk())
+    try {
+        const res = await handleLocationUpdate(
+            client,
+            { update_id: 1 },
+            locationMessage(),
+            'TOKEN',
+            'https://map.euc.kz',
+            true,
+        )
+        assertEquals(res.status, 200)
+        const ephemeral = calls.find(
+            (c) => methodOf(c.url) === 'sendMessage' && (c.body as { receiver_user_id?: number }).receiver_user_id,
+        )!
+        assertEquals((ephemeral.body as { receiver_user_id: number }).receiver_user_id, 777)
+        assertEquals((ephemeral.body as { chat_id: number }).chat_id, -500)
+        const text = (ephemeral.body as { text: string }).text
+        assertEquals(text.includes('Кроме тебя катают: 2 райдера'), true)
+        assertEquals(text.includes('Ближайший к тебе райдер: @vanton'), true)
+        assertEquals(text.includes('у КБТУ'), true)
+    } finally {
+        restore()
+    }
+})
+
+Deno.test('handleLocationUpdate: старт live без других райдеров → «катаешь один»', async () => {
+    const { client } = locationSupabase()
+    const { calls, restore } = installFetchMock(() => tgOk())
+    try {
+        await handleLocationUpdate(client, { update_id: 4 }, locationMessage(), 'TOKEN', 'https://map.euc.kz', true)
+        const ephemeral = calls.find(
+            (c) => methodOf(c.url) === 'sendMessage' && (c.body as { receiver_user_id?: number }).receiver_user_id,
+        )!
+        assertEquals((ephemeral.body as { text: string }).text.includes('Пока ты катаешь один'), true)
+    } finally {
+        restore()
+    }
+})
+
+Deno.test('handleLocationUpdate: апдейт движения (isLiveStart=false) → без онбординга', async () => {
+    const { client } = locationSupabase()
+    const { calls, restore } = installFetchMock(() => tgOk())
+    try {
+        await handleLocationUpdate(client, { update_id: 2 }, locationMessage(), 'TOKEN', 'https://map.euc.kz', false)
+        assertEquals(
+            calls.some((c) => methodOf(c.url) === 'sendMessage'),
+            false,
+        )
+    } finally {
+        restore()
+    }
+})
+
+Deno.test('handleLocationUpdate: старт live в личке → без онбординга (эфемерка только в группе)', async () => {
+    const { client } = locationSupabase()
+    const { calls, restore } = installFetchMock(() => tgOk())
+    try {
+        await handleLocationUpdate(
+            client,
+            { update_id: 3 },
+            locationMessage({ chatType: 'private' }),
+            'TOKEN',
+            'https://map.euc.kz',
+            true,
+        )
+        assertEquals(
+            calls.some((c) => methodOf(c.url) === 'sendMessage'),
+            false,
+        )
     } finally {
         restore()
     }

--- a/supabase/functions/telegram-location-bot/_handlers.ts
+++ b/supabase/functions/telegram-location-bot/_handlers.ts
@@ -7,19 +7,26 @@
  */
 import type { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import {
+    ACTIVE_RIDER_WINDOW_MINUTES,
     BACKFILL_ERROR_SAMPLE_LIMIT,
     DEFAULT_BACKFILL_MAX_PROFILES_PER_RUN,
     TELEGRAM_AVATARS_BUCKET,
     UUID_RE,
     buildAnnouncementText,
     buildCancelledAnnouncementText,
+    buildLiveLocationEphemeralText,
     buildNewsText,
+    buildRsvpEphemeralText,
     buildRsvpKeyboard,
     isAvatarUrlSafe,
     parsePositiveIntEnv,
     parseRsvpCallbackData,
+    selectNearestRider,
+    type ActiveRider,
     type AnnouncementEvent,
     type EventTypeValue,
+    type NamedPoint,
+    type NearestRider,
     type TelegramCallbackQuery,
     type TelegramInlineQuery,
     type TelegramInlineQueryResultArticle,
@@ -230,6 +237,43 @@ export async function callTelegramApi(
     }
 }
 
+/**
+ * Best-effort приватный (эфемерный) ответ внутри группового чата — виден только
+ * receiverUserId (и боту), без спама в общую ленту. Отправка через sendMessage +
+ * receiver_user_id. Ошибка не влияет на основной поток (в т.ч. если фича ещё недоступна
+ * боту) — только логируется. Возвращает id эфемерного сообщения (для правки/удаления) либо null.
+ */
+export async function sendEphemeralMessage(
+    chatId: number,
+    receiverUserId: number,
+    text: string,
+    botToken: string,
+): Promise<number | null> {
+    const result = await callTelegramApi(
+        'sendMessage',
+        {
+            chat_id: chatId,
+            receiver_user_id: receiverUserId,
+            text,
+            parse_mode: 'HTML',
+            disable_web_page_preview: true,
+        },
+        botToken,
+    )
+    if (!result.ok) {
+        console.info('[telegram-location-bot] Эфемерное сообщение не отправлено', {
+            chat_id: chatId,
+            receiver_user_id: receiverUserId,
+            description: result.description,
+        })
+        return null
+    }
+    const res = result.result
+    return res && typeof res === 'object'
+        ? ((res as { ephemeral_message_id?: number }).ephemeral_message_id ?? null)
+        : null
+}
+
 // ───────────────────────────── Анонсы событий + RSVP ─────────────────────────────
 
 /** Текущее число участников даты. */
@@ -283,12 +327,24 @@ export async function handleCallbackQuery(
     }
     const eventDateId = parsed.eventDateId
 
-    // Дата должна существовать и быть не отменённой.
+    // Дата должна существовать и быть не отменённой. starts_at + map_events нужны для
+    // эфемерной карточки-подтверждения (шапка «тип · название · дата»).
     const { data: dateRow, error: dateError } = await supabase
         .from('map_event_dates')
-        .select('id, cancelled, event_id')
+        .select('id, cancelled, event_id, starts_at, map_events(id, type, title, location_text)')
         .eq('id', eventDateId)
-        .maybeSingle<{ id: string; cancelled: boolean; event_id: number }>()
+        .maybeSingle<{
+            id: string
+            cancelled: boolean
+            event_id: number
+            starts_at: string
+            map_events: {
+                id: number
+                type: EventTypeValue
+                title: string
+                location_text: string | null
+            } | null
+        }>()
     if (dateError || !dateRow || dateRow.cancelled) {
         await callTelegramApi(
             'answerCallbackQuery',
@@ -318,22 +374,43 @@ export async function handleCallbackQuery(
         .maybeSingle<{ id: string }>()
 
     let toastText: string
+    // joined: true — записался, false — вышел, null — операция не удалась (эфемерку не шлём).
+    let joined: boolean | null
     if (existing) {
         await supabase.from('map_event_participants').delete().eq('id', existing.id)
         toastText = 'Вы больше не участвуете'
+        joined = false
     } else {
         const { error: insertError } = await supabase
             .from('map_event_participants')
             .insert({ event_date_id: eventDateId, telegram_user_id: cb.from.id })
         // 23505 — гонка: уже записан, считаем идемпотентным успехом.
-        toastText =
-            insertError && insertError.code !== '23505'
-                ? 'Не удалось записаться, попробуйте позже'
-                : 'Вы участвуете! 🛞'
+        if (insertError && insertError.code !== '23505') {
+            toastText = 'Не удалось записаться, попробуйте позже'
+            joined = null
+        } else {
+            toastText = 'Вы участвуете! 🛞'
+            joined = true
+        }
     }
 
     const count = await countEventParticipants(supabase, eventDateId)
     await callTelegramApi('answerCallbackQuery', { callback_query_id: cb.id, text: toastText }, botToken)
+
+    // Приватная (эфемерная) карточка-подтверждение в том же чате поверх куцего тоста:
+    // «ты в списке / вышел» + шапка события + ссылка на страницу. Best-effort — на запись
+    // участника не влияет; шлём только при известном событии и доступном chat_id.
+    const ev = dateRow.map_events
+    const chatId = cb.message?.chat.id
+    if (joined !== null && ev && typeof chatId === 'number') {
+        const text = buildRsvpEphemeralText(
+            { id: ev.id, type: ev.type, title: ev.title, location_text: ev.location_text },
+            dateRow.starts_at,
+            joined,
+            mapBaseUrl,
+        )
+        await sendEphemeralMessage(chatId, cb.from.id, text, botToken)
+    }
 
     // Счётчик участников привязан к дате, а не к одному сообщению: дата могла быть
     // разослана в несколько чатов. Обновляем клавиатуру во ВСЕХ живых анонсах даты,
@@ -1449,6 +1526,62 @@ export async function handleAvatarBackfill(
 }
 
 /**
+ * Собирает данные для эфемерной карточки старта live-геопозиции: сколько ДРУГИХ райдеров
+ * сейчас онлайн (последняя геопозиция в окне ACTIVE_RIDER_WINDOW_MINUTES) и ближайший из них.
+ * telegram_locations читаем окном по created_at, дедуплицируем до последней записи на юзера,
+ * исключаем самого автора. Точки — все включённые (для ориентира «у <точка>»).
+ * Ошибки чтения не критичны — деградируем в «катаешь один».
+ */
+async function gatherLiveLocationStats(
+    supabase: SupabaseClient,
+    selfUserId: number,
+    userLon: number,
+    userLat: number,
+): Promise<{ otherRidersCount: number; nearest: NearestRider | null }> {
+    const windowStartIso = new Date(Date.now() - ACTIVE_RIDER_WINDOW_MINUTES * 60_000).toISOString()
+
+    const { data: locationRows } = await supabase
+        .from('telegram_locations')
+        .select('telegram_user_id, username, first_name, longitude, latitude')
+        .gte('created_at', windowStartIso)
+        .order('created_at', { ascending: false })
+        .limit(1000)
+
+    const seen = new Set<number>()
+    const riders: ActiveRider[] = []
+    for (const row of (locationRows ?? []) as Array<{
+        telegram_user_id: number
+        username: string | null
+        first_name: string | null
+        longitude: number
+        latitude: number
+    }>) {
+        if (row.telegram_user_id === selfUserId || seen.has(row.telegram_user_id)) continue
+        seen.add(row.telegram_user_id)
+        riders.push({
+            telegramUserId: row.telegram_user_id,
+            username: row.username,
+            firstName: row.first_name,
+            longitude: row.longitude,
+            latitude: row.latitude,
+        })
+    }
+
+    if (riders.length === 0) return { otherRidersCount: 0, nearest: null }
+
+    const { data: pointRows } = await supabase
+        .from('map_points')
+        .select('title, coordinates')
+        .eq('flag_disabled', false)
+
+    const points: NamedPoint[] = ((pointRows ?? []) as Array<{ title: string; coordinates: number[] }>)
+        .filter((p) => Array.isArray(p.coordinates) && p.coordinates.length >= 2)
+        .map((p) => ({ title: p.title, longitude: p.coordinates[0]!, latitude: p.coordinates[1]! }))
+
+    return { otherRidersCount: riders.length, nearest: selectNearestRider(userLon, userLat, riders, points) }
+}
+
+/**
  * Сохраняет live-геопозицию из сообщения: обновляет профиль (с аватаром при необходимости)
  * и вставляет строку в telegram_locations. Возвращает HTTP Response для вебхука.
  */
@@ -1457,6 +1590,10 @@ export async function handleLocationUpdate(
     update: { update_id: number },
     message: TelegramMessage,
     botToken: string | undefined,
+    mapBaseUrl: string,
+    // true — это стартовое сообщение live-трансляции (а не апдейт движения): только тогда
+    // шлём онбординг-подсказку, иначе спамили бы на каждое перемещение.
+    isLiveStart: boolean,
 ): Promise<Response> {
     const location = message.location!
     const from = message.from!
@@ -1567,6 +1704,20 @@ export async function handleLocationUpdate(
             error,
         })
         return new Response('Internal Server Error', { status: 500 })
+    }
+
+    // Онбординг: при СТАРТЕ live-трансляции в группе приватно (эфемерно) показываем автору
+    // карточку — он на карте, сколько ещё райдеров онлайн и кто ближайший. Только в группе
+    // (в личке смысла нет), best-effort: на сохранение геопозиции не влияет, ошибка логируется.
+    if (isLiveStart && botToken && message.chat.type && message.chat.type !== 'private') {
+        const stats = await gatherLiveLocationStats(supabase, telegramUserId, location.longitude, location.latitude)
+        const text = buildLiveLocationEphemeralText({
+            mapBaseUrl,
+            telegramUserId,
+            otherRidersCount: stats.otherRidersCount,
+            nearest: stats.nearest,
+        })
+        await sendEphemeralMessage(message.chat.id, telegramUserId, text, botToken)
     }
 
     return new Response('ok', { status: 200 })

--- a/supabase/functions/telegram-location-bot/_pure.test.ts
+++ b/supabase/functions/telegram-location-bot/_pure.test.ts
@@ -3,15 +3,23 @@ import {
     buildAnnouncementHeader,
     buildAnnouncementText,
     buildCancelledAnnouncementText,
+    buildLiveLocationEphemeralText,
     buildNewsText,
+    buildRsvpEphemeralText,
     buildRsvpKeyboard,
     escapeHtml,
+    formatDistance,
     formatParticipateButtonLabel,
     getMessageWithLocation,
+    haversineMeters,
     isAvatarUrlSafe,
     parsePositiveIntEnv,
     parseRsvpCallbackData,
+    pluralizeRiders,
+    selectNearestRider,
+    type ActiveRider,
     type AnnouncementEvent,
+    type NamedPoint,
     type TelegramMessage,
     type TelegramUpdate,
 } from './_pure.ts'
@@ -140,6 +148,109 @@ Deno.test(
         assertEquals(text, '❌ <b>ОТМЕНЕНО</b>\n\n<s>вторник, 14 июля, 19:00 (скоро)</s>')
     },
 )
+
+Deno.test('formatDistance: метры (округление до 10) и километры', () => {
+    assertEquals(formatDistance(0), '0 м')
+    assertEquals(formatDistance(7), '10 м')
+    assertEquals(formatDistance(134), '130 м')
+    assertEquals(formatDistance(950), '950 м')
+    assertEquals(formatDistance(997), '1.0 км')
+    assertEquals(formatDistance(1234), '1.2 км')
+    assertEquals(formatDistance(Number.NaN), '')
+})
+
+Deno.test('pluralizeRiders: русское склонение', () => {
+    assertEquals(pluralizeRiders(1), '1 райдер')
+    assertEquals(pluralizeRiders(2), '2 райдера')
+    assertEquals(pluralizeRiders(4), '4 райдера')
+    assertEquals(pluralizeRiders(5), '5 райдеров')
+    assertEquals(pluralizeRiders(11), '11 райдеров')
+    assertEquals(pluralizeRiders(21), '21 райдер')
+    assertEquals(pluralizeRiders(22), '22 райдера')
+    assertEquals(pluralizeRiders(0), '0 райдеров')
+})
+
+Deno.test('haversineMeters: ~0 на одной точке, разумный порядок на разнесённых', () => {
+    assertEquals(Math.round(haversineMeters(43.2, 76.9, 43.2, 76.9)), 0)
+    // ~0.001° по широте ≈ 111 м
+    const d = haversineMeters(43.2, 76.9, 43.201, 76.9)
+    assertEquals(d > 100 && d < 120, true)
+})
+
+Deno.test('selectNearestRider: пусто → null', () => {
+    assertEquals(selectNearestRider(76.9, 43.2, [], []), null)
+})
+
+Deno.test('selectNearestRider: выбирает ближайшего + ориентир при точке ближе 500 м', () => {
+    const riders: ActiveRider[] = [
+        { telegramUserId: 1, username: 'far', firstName: null, longitude: 76.95, latitude: 43.25 },
+        { telegramUserId: 2, username: 'vanton', firstName: null, longitude: 76.9013, latitude: 43.2 },
+    ]
+    // точка почти на позиции райдера 2 (в пределах 500 м)
+    const points: NamedPoint[] = [{ title: 'КБТУ', longitude: 76.9012, latitude: 43.2 }]
+    const nearest = selectNearestRider(76.9, 43.2, riders, points)
+    assertEquals(nearest?.name, '@vanton')
+    assertEquals(nearest?.atPointTitle, 'КБТУ')
+    assertEquals((nearest?.distanceMeters ?? 0) < 200, true)
+})
+
+Deno.test('selectNearestRider: точка дальше 500 м → без ориентира; имя из first_name с escape', () => {
+    const riders: ActiveRider[] = [
+        { telegramUserId: 3, username: null, firstName: '<Толя>', longitude: 76.9, latitude: 43.2 },
+    ]
+    const points: NamedPoint[] = [{ title: 'КБТУ', longitude: 77.5, latitude: 43.6 }]
+    const nearest = selectNearestRider(76.9, 43.2, riders, points)
+    assertEquals(nearest?.name, '&lt;Толя&gt;')
+    assertEquals(nearest?.atPointTitle, null)
+})
+
+Deno.test('buildLiveLocationEphemeralText: есть райдеры + ориентир', () => {
+    const text = buildLiveLocationEphemeralText({
+        mapBaseUrl: 'https://map.euc.kz',
+        telegramUserId: 12345,
+        otherRidersCount: 2,
+        nearest: { name: '@vanton', distanceMeters: 130, atPointTitle: 'КБТУ' },
+    })
+    assertEquals(
+        text,
+        '📍 Твоя геопозиция отображается на <a href="https://map.euc.kz/m/telegramuser/12345">map.euc.kz</a>\n' +
+            'Кроме тебя катают: 2 райдера\n' +
+            'Ближайший к тебе райдер: @vanton (130 м, у КБТУ)\n\n' +
+            'Делитесь геопозицией чаще — в конце сезона подведём классную статистику по самым популярным маршрутам города 🛞',
+    )
+})
+
+Deno.test('buildLiveLocationEphemeralText: никого рядом → «катаешь один»', () => {
+    const text = buildLiveLocationEphemeralText({
+        mapBaseUrl: 'https://map.euc.kz',
+        telegramUserId: 7,
+        otherRidersCount: 0,
+        nearest: null,
+    })
+    assertEquals(
+        text,
+        '📍 Твоя геопозиция отображается на <a href="https://map.euc.kz/m/telegramuser/7">map.euc.kz</a>\n' +
+            'Пока ты катаешь один — зови остальных!\n\n' +
+            'Делитесь геопозицией чаще — в конце сезона подведём классную статистику по самым популярным маршрутам города 🛞',
+    )
+})
+
+Deno.test('buildRsvpEphemeralText: записался → шапка + ссылка на /events/:id', () => {
+    const event: AnnouncementEvent = { id: 7, type: 'group_ride', title: 'Вечерняя', location_text: null }
+    const text = buildRsvpEphemeralText(event, '2026-07-14T14:00:00Z', true, 'https://map.euc.kz')
+    assertEquals(
+        text,
+        'Ты в списке участников! 🛞\n\n' +
+            'Покатушка · <b>Вечерняя</b>\n📅 вторник, 14 июля, 19:00 (<tg-time unix="1784037600" format="r">скоро</tg-time>)\n\n' +
+            '<a href="https://map.euc.kz/events/7">Открыть событие на карте</a>',
+    )
+})
+
+Deno.test('buildRsvpEphemeralText: вышел → без ссылки, шапка сохраняется', () => {
+    const event: AnnouncementEvent = { id: 7, type: 'event', title: 'X', location_text: null }
+    const text = buildRsvpEphemeralText(event, 'not-a-date', false, 'https://map.euc.kz')
+    assertEquals(text, 'Ты больше не участвуешь.\n\nМероприятие · <b>X</b>')
+})
 
 Deno.test('getMessageWithLocation: приоритет message → edited → channel', () => {
     const withLoc = (id: number): TelegramMessage => ({

--- a/supabase/functions/telegram-location-bot/_pure.ts
+++ b/supabase/functions/telegram-location-bot/_pure.ts
@@ -31,6 +31,9 @@ export type TelegramMessage = {
     chat: TelegramChat
     text?: string
     location?: TelegramLocation
+    // Эфемерные (приватные внутри чата) сообщения: кому адресовано и id внутри чата.
+    receiver_user?: TelegramUser
+    ephemeral_message_id?: number
 }
 
 export type TelegramInlineQuery = {
@@ -334,4 +337,154 @@ export function buildCancelledAnnouncementText(messageText: string): string {
  */
 export function buildNewsText(body: string): string {
     return escapeHtml(body.trim())
+}
+
+/** Окно «сейчас катает»: райдер активен, если его последняя геопозиция не старше стольких минут. */
+export const ACTIVE_RIDER_WINDOW_MINUTES = 60
+/** Порог «райдер на точке»: если ближайшая точка не дальше — показываем её как ориентир. */
+export const RIDER_AT_POINT_THRESHOLD_METERS = 500
+
+/** Активный райдер (последняя live-геопозиция) — для подсчёта «кроме тебя катают» и ближайшего. */
+export type ActiveRider = {
+    telegramUserId: number
+    username: string | null
+    firstName: string | null
+    longitude: number
+    latitude: number
+}
+
+/** Именованная точка карты (для ориентира «у <точка>»). */
+export type NamedPoint = {
+    title: string
+    longitude: number
+    latitude: number
+}
+
+/** Ближайший к пользователю райдер + опциональный ориентир-точка. */
+export type NearestRider = {
+    name: string
+    distanceMeters: number
+    atPointTitle: string | null
+}
+
+/** Расстояние по дуге большого круга в метрах (WGS84). */
+export function haversineMeters(lat1: number, lon1: number, lat2: number, lon2: number): number {
+    const earthRadiusM = 6_371_000
+    const toRad = (d: number) => (d * Math.PI) / 180
+    const dLat = toRad(lat2 - lat1)
+    const dLon = toRad(lon2 - lon1)
+    const h =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2)
+    return 2 * earthRadiusM * Math.asin(Math.sqrt(h))
+}
+
+/** «130 м» (округление до 10 м) для дистанций < 1 км, иначе «1.2 км». */
+export function formatDistance(meters: number): string {
+    if (!Number.isFinite(meters)) return ''
+    if (meters < 1000) {
+        const rounded = Math.max(0, Math.round(meters / 10) * 10)
+        // 995–999 м округлились бы до «1000 м» — красивее показать «1.0 км».
+        if (rounded < 1000) return `${String(rounded)} м`
+    }
+    return `${(meters / 1000).toFixed(1)} км`
+}
+
+/** Русское склонение: «1 райдер», «2 райдера», «5 райдеров». */
+export function pluralizeRiders(n: number): string {
+    const mod10 = n % 10
+    const mod100 = n % 100
+    if (mod10 === 1 && mod100 !== 11) return `${String(n)} райдер`
+    if (mod10 >= 2 && mod10 <= 4 && (mod100 < 10 || mod100 >= 20)) return `${String(n)} райдера`
+    return `${String(n)} райдеров`
+}
+
+/** Отображаемое имя райдера: @username либо экранированное имя, иначе «райдер». */
+function riderDisplayName(rider: ActiveRider): string {
+    if (rider.username) return `@${rider.username}`
+    const first = rider.firstName?.trim()
+    return first ? escapeHtml(first) : 'райдер'
+}
+
+/**
+ * Ближайший к (userLon, userLat) райдер: имя, дистанция от пользователя и — если райдер
+ * не дальше RIDER_AT_POINT_THRESHOLD_METERS от какой-либо точки — её название как ориентир.
+ * Возвращает null, если активных райдеров нет. Чистая (haversine, без I/O).
+ */
+export function selectNearestRider(
+    userLon: number,
+    userLat: number,
+    riders: ActiveRider[],
+    points: NamedPoint[],
+): NearestRider | null {
+    let best: { rider: ActiveRider; distanceMeters: number } | null = null
+    for (const rider of riders) {
+        const distanceMeters = haversineMeters(userLat, userLon, rider.latitude, rider.longitude)
+        if (!best || distanceMeters < best.distanceMeters) best = { rider, distanceMeters }
+    }
+    if (!best) return null
+
+    // Ближайшая к самому райдеру точка — ориентир, только если он реально рядом с ней.
+    let atPointTitle: string | null = null
+    let bestPointMeters = Number.POSITIVE_INFINITY
+    for (const point of points) {
+        const d = haversineMeters(best.rider.latitude, best.rider.longitude, point.latitude, point.longitude)
+        if (d < bestPointMeters) {
+            bestPointMeters = d
+            if (d <= RIDER_AT_POINT_THRESHOLD_METERS) atPointTitle = escapeHtml(point.title)
+            else atPointTitle = null
+        }
+    }
+
+    return { name: riderDisplayName(best.rider), distanceMeters: best.distanceMeters, atPointTitle }
+}
+
+/**
+ * Эфемерная (видна только автору внутри чата) карточка при СТАРТЕ live-геопозиции:
+ * ссылка на себя на карте, сколько ещё райдеров онлайн и ближайший из них (с ориентиром),
+ * призыв делиться чаще. Deep-link на свою метку — /m/telegramuser/<id>.
+ */
+export function buildLiveLocationEphemeralText(input: {
+    mapBaseUrl: string
+    telegramUserId: number
+    otherRidersCount: number
+    nearest: NearestRider | null
+}): string {
+    const selfUrl = `${input.mapBaseUrl}/m/telegramuser/${String(input.telegramUserId)}`
+    const lines = [`📍 Твоя геопозиция отображается на <a href="${selfUrl}">map.euc.kz</a>`]
+
+    if (input.otherRidersCount <= 0 || !input.nearest) {
+        lines.push('Пока ты катаешь один — зови остальных!')
+    } else {
+        lines.push(`Кроме тебя катают: ${pluralizeRiders(input.otherRidersCount)}`)
+        const at = input.nearest.atPointTitle ? `, у ${input.nearest.atPointTitle}` : ''
+        lines.push(
+            `Ближайший к тебе райдер: ${input.nearest.name} (${formatDistance(input.nearest.distanceMeters)}${at})`,
+        )
+    }
+
+    lines.push('')
+    lines.push(
+        'Делитесь геопозицией чаще — в конце сезона подведём классную статистику по самым популярным маршрутам города 🛞',
+    )
+    return lines.join('\n')
+}
+
+/**
+ * Эфемерная (видна только нажавшему кнопку внутри чата) карточка-подтверждение RSVP:
+ * при записи — «ты в списке» + шапка события (тип · название · дата) + ссылка на страницу;
+ * при выходе — «ты больше не участвуешь» + шапка. Ссылка — /events/:id (не /m/event/:id).
+ */
+export function buildRsvpEphemeralText(
+    event: AnnouncementEvent,
+    startsAtIso: string,
+    joined: boolean,
+    mapBaseUrl: string,
+): string {
+    const header = buildAnnouncementHeader(event, startsAtIso)
+    if (!joined) {
+        return `Ты больше не участвуешь.\n\n${header}`
+    }
+    const eventUrl = `${mapBaseUrl}/events/${String(event.id)}`
+    return `Ты в списке участников! 🛞\n\n${header}\n\n<a href="${eventUrl}">Открыть событие на карте</a>`
 }

--- a/supabase/functions/telegram-location-bot/index.ts
+++ b/supabase/functions/telegram-location-bot/index.ts
@@ -172,5 +172,8 @@ Deno.serve(async (req) => {
         return new Response('ok', { status: 200 })
     }
 
-    return handleLocationUpdate(supabase, update, message, botToken)
+    // Стартовое сообщение live-трансляции приходит как update.message; апдейты движения — как
+    // edited_message. Онбординг-подсказку шлём только на старте (см. handleLocationUpdate).
+    const isLiveStart = message === update.message
+    return handleLocationUpdate(supabase, update, message, botToken, mapBaseUrl, isLiveStart)
 })


### PR DESCRIPTION
## Summary

Приватные (эфемерные) ответы бота — видны только адресату внутри группового чата, через `sendMessage` + `receiver_user_id`. Общий примитив `sendEphemeralMessage` best-effort: ошибка или недоступность фичи не влияет на основной поток (запись RSVP, сохранение геопозиции).

**Внедрено:**
1. **RSVP-подтверждение** (`handleCallbackQuery`) — поверх короткого toast'а приватная карточка: при записи «Ты в списке участников» + шапка события + deep-link `/events/:id`; при выходе «Ты больше не участвуешь».
2. **Карточка live-геопозиции** (`handleLocationUpdate`) — при **старте** трансляции (не апдейт движения) в **группе**: «ты на карте `map.euc.kz`», сколько ещё райдеров онлайн (окно 60 мин) и ближайший из них с ориентиром «у ‹точка›» (если он ближе 500 м к любой точке `map_points`). При 0 других — «катаешь один».

Задеплоено в прод (`supabase functions deploy ... --use-api`), проверено вживую на тест-чате.

## Детали

- Новые чистые функции в `_pure.ts`: `haversineMeters`, `selectNearestRider`, `formatDistance`, `pluralizeRiders`, `buildRsvpEphemeralText`, `buildLiveLocationEphemeralText`; типы `Message.receiver_user`/`ephemeral_message_id`.
- Сбор статистики — `gatherLiveLocationStats` (последняя геопозиция каждого юзера в окне, ближайший по haversine, исключая автора).
- `docs/telegram-bot.md` — раздел «Эфемерные сообщения» переписан из «потенциал» в «внедрено».

## Test plan

- [x] `test:functions` (deno) — 95 passed
- [x] pre-commit целиком (lint, format, tsc, vitest 1084, deno, build, e2e 42) — зелёный
- [x] ручная проверка в тест-чате: RSVP-карточка и карточка геопозиции приходят